### PR TITLE
Add support for tasks which run different test filters.

### DIFF
--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FladleConfig.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FladleConfig.kt
@@ -1,0 +1,17 @@
+package com.osacky.flank.gradle
+
+interface FladleConfig {
+  var flankVersion: String
+  // Project id is automatically discovered by default. Use this to override the project id.
+  var projectId: String?
+  var serviceAccountCredentials: String?
+  var useOrchestrator: Boolean
+  var autoGoogleLogin: Boolean
+  var devices: List<Device>
+
+  // https://cloud.google.com/sdk/gcloud/reference/firebase/test/android/run
+  var testTargets: List<String>
+
+  var testShards: Int?
+  var repeatTests: Int?
+}

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FladleConfigImpl.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FladleConfigImpl.kt
@@ -1,0 +1,14 @@
+package com.osacky.flank.gradle
+
+data class FladleConfigImpl(
+  internal val name: String,
+  override var flankVersion: String,
+  override var projectId: String? = null,
+  override var serviceAccountCredentials: String? = null,
+  override var useOrchestrator: Boolean = false,
+  override var autoGoogleLogin: Boolean = false,
+  override var devices: List<Device> = listOf(Device("NexusLowRes", 28)),
+  override var testTargets: List<String> = emptyList(),
+  override var testShards: Int? = null,
+  override var repeatTests: Int? = null
+) : FladleConfig

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
@@ -26,7 +26,7 @@ open class FlankGradleExtension(project: Project) : FladleConfig {
     FladleConfigImpl(it, flankVersion, projectId, serviceAccountCredentials, useOrchestrator, autoGoogleLogin, devices, testTargets, testShards, repeatTests)
   }
 
-  fun targets(closure: Closure<*>) {
+  fun configs(closure: Closure<*>) {
     configs.configure(closure)
   }
 }

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
@@ -22,11 +22,11 @@ open class FlankGradleExtension(project: Project) : FladleConfig {
   var debugApk: String? = null
   var instrumentationApk: String? = null
 
-  val targets: NamedDomainObjectContainer<FladleConfigImpl> = project.container(FladleConfigImpl::class.java) {
+  val configs: NamedDomainObjectContainer<FladleConfigImpl> = project.container(FladleConfigImpl::class.java) {
     FladleConfigImpl(it, flankVersion, projectId, serviceAccountCredentials, useOrchestrator, autoGoogleLogin, devices, testTargets, testShards, repeatTests)
   }
 
   fun targets(closure: Closure<*>) {
-    targets.configure(closure)
+    configs.configure(closure)
   }
 }

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
@@ -1,19 +1,32 @@
 package com.osacky.flank.gradle
 
-open class FlankGradleExtension {
-  var flankVersion: String = "v3.2.1"
+import groovy.lang.Closure
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.Project
+
+open class FlankGradleExtension(project: Project) : FladleConfig {
+  override var flankVersion: String = "v3.2.1"
   // Project id is automatically discovered by default. Use this to override the project id.
-  var projectId: String? = null
-  var serviceAccountCredentials: String? = null
-  var debugApk: String? = null
-  var instrumentationApk: String? = null
-  var useOrchestrator: Boolean = false
-  var autoGoogleLogin: Boolean = false
-  var devices: List<Device> = listOf(Device("NexusLowRes", 28))
+  override var projectId: String? = null
+  override var serviceAccountCredentials: String? = null
+  override var useOrchestrator: Boolean = false
+  override var autoGoogleLogin: Boolean = false
+  override var devices: List<Device> = listOf(Device("NexusLowRes", 28))
 
   // https://cloud.google.com/sdk/gcloud/reference/firebase/test/android/run
-  var testTargets: List<String> = emptyList()
+  override var testTargets: List<String> = emptyList()
 
-  var testShards: Int? = null
-  var repeatTests: Int? = null
+  override var testShards: Int? = null
+  override var repeatTests: Int? = null
+
+  var debugApk: String? = null
+  var instrumentationApk: String? = null
+
+  val targets: NamedDomainObjectContainer<FladleConfigImpl> = project.container(FladleConfigImpl::class.java) {
+    FladleConfigImpl(it, flankVersion, projectId, serviceAccountCredentials, useOrchestrator, autoGoogleLogin, devices, testTargets, testShards, repeatTests)
+  }
+
+  fun targets(closure: Closure<*>) {
+    targets.configure(closure)
+  }
 }

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradlePlugin.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradlePlugin.kt
@@ -6,13 +6,14 @@ import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.Exec
+import org.gradle.api.tasks.TaskContainer
 import org.gradle.util.GradleVersion
 
 class FlankGradlePlugin : Plugin<Project> {
 
   override fun apply(target: Project) {
     checkMinimumGradleVersion()
-    val extension = target.extensions.create("fladle", FlankGradleExtension::class.java)
+    val extension = target.extensions.create("fladle", FlankGradleExtension::class.java, target)
     configureTasks(target, extension)
   }
 
@@ -37,24 +38,46 @@ class FlankGradlePlugin : Plugin<Project> {
         dest("${project.fladleDir}/flank.jar")
         onlyIfModified(true)
       }
+    }
 
-      register("printYml") {
-        description = "Print the flank.yml file to the console."
-        doLast {
-          println(YamlWriter().createConfigProps(extension))
+    project.afterEvaluate {
+      tasks.apply {
+        createTasksForConfig(extension, extension, project, "")
+
+        extension.targets.forEach {
+          createTasksForConfig(extension, it, project, it.name)
         }
       }
+    }
+  }
 
-      val writeConfigProps = project.tasks.register("writeConfigProps", YamlConfigWriterTask::class.java, extension)
-
-      project.tasks.register("flankDoctor", Exec::class.java) {
-        description = "Finds problems with the current configuration."
-        workingDir("${project.fladleDir}/")
-        commandLine("java", "-jar", "flank.jar", "firebase", "test", "android", "doctor")
-        dependsOn(named("downloadFlank"), writeConfigProps)
+  private fun TaskContainer.createTasksForConfig(extension: FlankGradleExtension, config: FladleConfig, project: Project, name: String) {
+    register("printYml$name") {
+      description = "Print the flank.yml file to the console."
+      doLast {
+        println(YamlWriter().createConfigProps(config, extension))
       }
+    }
 
-      register("runFlank", RunFlankTask::class.java, extension)
+    val writeConfigProps = project.tasks.register("writeConfigProps$name", YamlConfigWriterTask::class.java, config, extension)
+
+    project.tasks.register("flankDoctor$name", Exec::class.java) {
+      description = "Finds problems with the current configuration."
+      workingDir("${project.fladleDir}/")
+      commandLine("java", "-jar", "flank.jar", "firebase", "test", "android", "doctor")
+      dependsOn(named("downloadFlank"), writeConfigProps)
+    }
+
+    val execFlank = project.tasks.register("execFlank$name", Exec::class.java) {
+      description = "Runs instrumentation tests using flank on firebase test lab."
+      workingDir("${project.fladleDir}/")
+      commandLine("java", "-jar", "flank.jar", "firebase", "test", "android", "run")
+      environment(mapOf("GOOGLE_APPLICATION_CREDENTIALS" to "${config.serviceAccountCredentials}"))
+      dependsOn(named("downloadFlank"), named("writeConfigProps$name"))
+    }
+
+    register("runFlank$name", RunFlankTask::class.java, config).configure {
+      dependsOn(execFlank)
     }
   }
 

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradlePlugin.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradlePlugin.kt
@@ -44,7 +44,7 @@ class FlankGradlePlugin : Plugin<Project> {
       tasks.apply {
         createTasksForConfig(extension, extension, project, "")
 
-        extension.targets.forEach {
+        extension.configs.forEach {
           createTasksForConfig(extension, it, project, it.name)
         }
       }

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/RunFlankTask.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/RunFlankTask.kt
@@ -1,22 +1,12 @@
 package com.osacky.flank.gradle
 
 import org.gradle.api.DefaultTask
-import org.gradle.api.tasks.Exec
 import javax.inject.Inject
 
-open class RunFlankTask @Inject constructor(private val extension: FlankGradleExtension) : DefaultTask() {
+open class RunFlankTask @Inject constructor(private val extension: FladleConfig) : DefaultTask() {
 
   init {
     description = "Runs instrumentation tests using flank on firebase test lab."
-
-    val execFlank = project.tasks.register("execFlank", Exec::class.java) {
-        description = "Runs instrumentation tests using flank on firebase test lab."
-        workingDir("${project.fladleDir}/")
-        commandLine("java", "-jar", "flank.jar", "firebase", "test", "android", "run")
-        environment(mapOf("GOOGLE_APPLICATION_CREDENTIALS" to "${extension.serviceAccountCredentials}"))
-        dependsOn(named("downloadFlank"), named("writeConfigProps"))
-    }
-    dependsOn(execFlank)
   }
 
   private fun named(taskName: String) = project.tasks.named(taskName)

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/YamlConfigWriterTask.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/YamlConfigWriterTask.kt
@@ -4,7 +4,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 import javax.inject.Inject
 
-open class YamlConfigWriterTask @Inject constructor(private val extension: FlankGradleExtension) : DefaultTask() {
+open class YamlConfigWriterTask @Inject constructor(private val config: FladleConfig, private val extension: FlankGradleExtension) : DefaultTask() {
 
   private val yamlWriter = YamlWriter()
 
@@ -14,6 +14,6 @@ open class YamlConfigWriterTask @Inject constructor(private val extension: Flank
 
   @TaskAction
   fun writeFile() {
-    project.file("${project.fladleDir}/flank.yml").writeText(yamlWriter.createConfigProps(extension))
+    project.file("${project.fladleDir}/flank.yml").writeText(yamlWriter.createConfigProps(config, extension))
   }
 }

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/YamlWriter.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/YamlWriter.kt
@@ -4,26 +4,26 @@ import org.gradle.internal.impldep.com.google.common.annotations.VisibleForTesti
 
 internal class YamlWriter {
 
-  internal fun createConfigProps(extension: FlankGradleExtension): String {
-    val deviceString = createDeviceString(extension.devices)
-    val additionalProperties = writeAdditionalProperties(extension)
-    val flankProperties = writeFlankProperties(extension)
+  internal fun createConfigProps(config: FladleConfig, extension: FlankGradleExtension): String {
+    val deviceString = createDeviceString(config.devices)
+    val additionalProperties = writeAdditionalProperties(config)
+    val flankProperties = writeFlankProperties(config)
 
     checkNotNull(extension.debugApk) { "debugApk cannot be null" }
     checkNotNull(extension.instrumentationApk) { "instrumentationApk cannot be null" }
     return """gcloud:
       |  app: ${extension.debugApk}
       |  test: ${extension.instrumentationApk}
-      |  use-orchestrator: ${extension.useOrchestrator}
-      |  auto-google-login: ${extension.autoGoogleLogin}
-      |${createProjectIdString(extension)}
+      |  use-orchestrator: ${config.useOrchestrator}
+      |  auto-google-login: ${config.autoGoogleLogin}
+      |${createProjectIdString(config)}
       |$deviceString
       |$additionalProperties
       |$flankProperties
     """.trimMargin()
   }
 
-  internal fun writeFlankProperties(extension: FlankGradleExtension): String {
+  internal fun writeFlankProperties(extension: FladleConfig): String {
     val builder = StringBuilder()
     val testShards = extension.testShards
     val repeatTests = extension.repeatTests
@@ -39,7 +39,7 @@ internal class YamlWriter {
     return builder.toString()
   }
 
-  internal fun writeAdditionalProperties(extension: FlankGradleExtension): String {
+  internal fun writeAdditionalProperties(extension: FladleConfig): String {
     val builder = StringBuilder()
     val testTargets = extension.testTargets
     if (testTargets.isNotEmpty()) {
@@ -52,7 +52,7 @@ internal class YamlWriter {
     return builder.toString()
   }
 
-  internal fun createProjectIdString(extension: FlankGradleExtension): String {
+  internal fun createProjectIdString(extension: FladleConfig): String {
     return if (extension.projectId != null) {
       "  project: ${extension.projectId}"
     } else {

--- a/buildSrc/src/test/java/com/osacky/flank/gradle/MultipleConfigsTest.kt
+++ b/buildSrc/src/test/java/com/osacky/flank/gradle/MultipleConfigsTest.kt
@@ -1,0 +1,56 @@
+package com.osacky.flank.gradle
+
+import com.google.common.truth.Truth.assertThat
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class MultipleConfigsTest {
+  @get:Rule
+  var testProjectRoot = TemporaryFolder()
+
+  @Test
+  fun checkCanPrintSecondConfig() {
+    val file = testProjectRoot.newFile("build.gradle")
+    file.writeText("""
+      |plugins {
+      |  id "com.osacky.fladle"
+      |}
+      |
+      |fladle {
+      |  serviceAccountCredentials("flank-gradle-service.json")
+      |  debugApk("foo.apk")
+      |  instrumentationApk("instrument.apk")
+      |
+      |  testTargets = ['default']
+      |  configs {
+      |    orange {
+      |      testTargets = ['override']
+      |    }
+      |  }
+      |}
+    """.trimMargin())
+    val result = GradleRunner.create()
+        .withPluginClasspath()
+        .withArguments("printYmlOrange")
+        .withProjectDir(testProjectRoot.root)
+        .build()
+
+    assertThat(result.output).contains("""
+      |gcloud:
+      |  app: foo.apk
+      |  test: instrument.apk
+      |  use-orchestrator: false
+      |  auto-google-login: false
+      |# projectId will be automatically discovered
+      |  device:
+      |  - model: NexusLowRes
+      |    version: 28
+      |
+      |  test-targets:
+      |  - override
+      |
+    """.trimMargin())
+  }
+}

--- a/buildSrc/src/test/java/com/osacky/flank/gradle/YamlWriterTest.kt
+++ b/buildSrc/src/test/java/com/osacky/flank/gradle/YamlWriterTest.kt
@@ -1,12 +1,22 @@
 package com.osacky.flank.gradle
 
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Assert.assertEquals
 import org.junit.Assert.fail
+import org.junit.Before
 import org.junit.Test
 
 class YamlWriterTest {
 
   internal val yamlWriter = YamlWriter()
+
+  private lateinit var project: Project
+
+  @Before
+  fun setup() {
+    project = ProjectBuilder.builder().withName("project").build()
+  }
 
   @Test
   fun testWriteSingleDevice() {
@@ -63,9 +73,9 @@ class YamlWriterTest {
 
   @Test
   fun verifyDebugApkThrowsError() {
-    val extension = FlankGradleExtension()
+    val extension = FlankGradleExtension(project)
     try {
-      yamlWriter.createConfigProps(extension)
+      yamlWriter.createConfigProps(extension, extension)
       fail()
     } catch (expected: IllegalStateException) {
       assertEquals("debugApk cannot be null", expected.message)
@@ -74,11 +84,11 @@ class YamlWriterTest {
 
   @Test
   fun verifyInstrumentationApkThrowsError() {
-    val extension = FlankGradleExtension().apply {
+    val extension = FlankGradleExtension(project).apply {
       debugApk = "path"
     }
     try {
-      yamlWriter.createConfigProps(extension)
+      yamlWriter.createConfigProps(extension, extension)
       fail()
     } catch (expected: IllegalStateException) {
       assertEquals("instrumentationApk cannot be null", expected.message)
@@ -87,7 +97,7 @@ class YamlWriterTest {
 
   @Test
   fun writeNoTestShards() {
-    val extension = FlankGradleExtension().apply {
+    val extension = FlankGradleExtension(project).apply {
     }
 
     assertEquals("", yamlWriter.writeFlankProperties(extension))
@@ -95,7 +105,7 @@ class YamlWriterTest {
 
   @Test
   fun writeTestShardOption() {
-    val extension = FlankGradleExtension().apply {
+    val extension = FlankGradleExtension(project).apply {
       testShards = 5
     }
 
@@ -105,7 +115,7 @@ class YamlWriterTest {
 
   @Test
   fun writeNoTestRepeats() {
-    val extension = FlankGradleExtension().apply {
+    val extension = FlankGradleExtension(project).apply {
       repeatTests = null
     }
 
@@ -114,7 +124,7 @@ class YamlWriterTest {
 
   @Test
   fun writeTestRepeats() {
-    val extension = FlankGradleExtension().apply {
+    val extension = FlankGradleExtension(project).apply {
       repeatTests = 5
     }
 
@@ -124,7 +134,7 @@ class YamlWriterTest {
 
   @Test
   fun writeTestShardAndRepeatOption() {
-    val extension = FlankGradleExtension().apply {
+    val extension = FlankGradleExtension(project).apply {
       testShards = 5
       repeatTests = 2
     }
@@ -136,7 +146,7 @@ class YamlWriterTest {
 
   @Test
   fun writeNoTestTargets() {
-    val extension = FlankGradleExtension().apply {
+    val extension = FlankGradleExtension(project).apply {
       testTargets = listOf()
     }
 
@@ -145,7 +155,7 @@ class YamlWriterTest {
 
   @Test
   fun writeSingleTestTargets() {
-    val extension = FlankGradleExtension().apply {
+    val extension = FlankGradleExtension(project).apply {
       testTargets = listOf("class com.example.Foo#testThing")
     }
 
@@ -155,7 +165,7 @@ class YamlWriterTest {
 
   @Test
   fun writeMultipleTestTargets() {
-    val extension = FlankGradleExtension().apply {
+    val extension = FlankGradleExtension(project).apply {
       testTargets = listOf("class com.example.Foo#testThing", "class com.example.Foo#testThing2")
     }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -19,7 +19,7 @@ android {
 
 fladle {
     serviceAccountCredentials("${project.file("flank-gradle-5cf02dc90531.json")}")
-    useOrchestrator = false
+    useOrchestrator = true
     testTargets = [
             "class com.osacky.flank.gradle.sample.ExampleInstrumentedTest#seeView"
     ]
@@ -27,6 +27,14 @@ fladle {
             new Device("NexusLowRes", 28, null, null),
             new Device("Nexus5", 23, null, null)
     ]
+    targets {
+        oranges {
+            useOrchestrator = false
+            testTargets = [
+                    "class com.osacky.flank.gradle.sample.ExampleInstrumentedTest#runAndFail"
+            ]
+        }
+    }
 }
 
 dependencies {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -27,7 +27,7 @@ fladle {
             new Device("NexusLowRes", 28, null, null),
             new Device("Nexus5", 23, null, null)
     ]
-    targets {
+    configs {
         oranges {
             useOrchestrator = false
             testTargets = [


### PR DESCRIPTION
Use NamedDomainObjectContainer to allow the tasks to be named.

Fixes #5