### PR TITLE
Use Flank as a maven artifact.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ fladle {
         new Device("Nexus5", 23, null, null)
     ]
     projectId("flank-gradle")
-    flankVersion("v3.1.1")
+    flankVersion("4.4.0")
     debugApk("$buildDir/outputs/apk/debug/sample-debug.apk")
     instrumentationApk("$buildDir/outputs/apk/androidTest/debug/sample-debug-androidTest.apk"
     autoGoogleLogin = true
@@ -108,7 +108,7 @@ This is automatically discovered based on the service credential by default.
 ### flankVersion
 `flankVersion("flank_snapshot")` to specify a Flank snapshot.
 
-`flankVersion("v3.1.1")` to specify a specific Flank version.
+`flankVersion("4.4.0")` to specify a specific Flank version.
 
 
 ### debugApk

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,9 +4,6 @@ version = "0.4.1"
 repositories {
   google()
   jcenter()
-  maven {
-    url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
-  }
 }
 
 plugins {
@@ -20,8 +17,6 @@ dependencies {
   compileOnly(gradleApi())
   implementation("com.android.tools.build:gradle:3.3.1")
 
-  implementation("de.undercouch:gradle-download-task:4.0.0-SNAPSHOT")
-
   testImplementation(gradleTestKit())
   testImplementation("junit:junit:4.12")
   testImplementation("com.google.truth:truth:0.42")
@@ -34,7 +29,7 @@ kotlinter {
 pluginBundle {
   website = "https://github.com/runningcode/fladle"
   vcsUrl = "https://github.com/runningcode/fladle"
-  tags = listOf("flank", "testing", "android")
+  tags = listOf("flank", "testing", "android", "fladle")
 
   mavenCoordinates {
     artifactId = "fladle"

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
@@ -5,7 +5,7 @@ import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 
 open class FlankGradleExtension(project: Project) : FladleConfig {
-  override var flankVersion: String = "v4.4.0"
+  override var flankVersion: String = "4.4.0"
   // Project id is automatically discovered by default. Use this to override the project id.
   override var projectId: String? = null
   override var serviceAccountCredentials: String? = null


### PR DESCRIPTION
This removes the need to redownload flank every time.
This also removes the snapshot dependencies and the Download task
dependencies.

Fixes #3