### PR TITLE
37: JavaExec task to use classpath instead of Jar directly

### DIFF
--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradlePlugin.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradlePlugin.kt
@@ -71,8 +71,9 @@ class FlankGradlePlugin : Plugin<Project> {
       description = "Finds problems with the current configuration."
       group = TASK_GROUP
       workingDir("${project.fladleDir}/")
-      main = "-jar"
-      args = listOf(project.fladleConfig.singleFile.absolutePath, "firebase", "test", "android", "doctor")
+      classpath = project.fladleConfig
+      main = "ftl.Main"
+      args = listOf("firebase", "test", "android", "doctor")
       dependsOn(writeConfigProps)
     }
 
@@ -80,8 +81,9 @@ class FlankGradlePlugin : Plugin<Project> {
       description = "Runs instrumentation tests using flank on firebase test lab."
       group = TASK_GROUP
       workingDir("${project.fladleDir}/")
-      main = "-jar"
-      args = listOf(project.fladleConfig.singleFile.absolutePath, "firebase", "test", "android", "run")
+      classpath = project.fladleConfig
+      main = "ftl.Main"
+      args = listOf("firebase", "test", "android", "run")
       environment(mapOf("GOOGLE_APPLICATION_CREDENTIALS" to "${config.serviceAccountCredentials}"))
       dependsOn(named("writeConfigProps$name"))
     }

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/YamlConfigWriterTask.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/YamlConfigWriterTask.kt
@@ -18,6 +18,10 @@ open class YamlConfigWriterTask @Inject constructor(private val config: FladleCo
 
   @TaskAction
   fun writeFile() {
-    project.file("${project.fladleDir}/flank.yml").writeText(yamlWriter.createConfigProps(config, extension))
+    val fladleDir = project.file(project.fladleDir)
+    if (!fladleDir.exists()) {
+      fladleDir.mkdirs()
+    }
+    fladleDir.resolve("flank.yml").writeText(yamlWriter.createConfigProps(config, extension))
   }
 }


### PR DESCRIPTION
Fixes also the issue in case the `build/fladle` dir did not exists