### PR TITLE
52: `shardTime` config property not written to flank.yml

### DIFF
--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
@@ -56,6 +56,7 @@ open class FlankGradleExtension(project: Project) : FladleConfig {
       devices = devices,
       testTargets = testTargets,
       testShards = testShards,
+      shardTime = shardTime,
       repeatTests = repeatTests,
       smartFlankGcsPath = smartFlankGcsPath,
       resultsHistoryName = resultsHistoryName,

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/YamlWriter.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/YamlWriter.kt
@@ -23,15 +23,19 @@ internal class YamlWriter {
 
   internal fun writeFlankProperties(config: FladleConfig): String = buildString {
     val testShards = config.testShards
+    val shardTime = config.shardTime
     val repeatTests = config.repeatTests
     val smartFlankGcsPath = config.smartFlankGcsPath
     val filesToDownload = config.filesToDownload
     val projectId = config.projectId
-    if (testShards != null || repeatTests != null || smartFlankGcsPath != null || filesToDownload.isNotEmpty() || projectId != null) {
+    if (testShards != null || shardTime != null || repeatTests != null || smartFlankGcsPath != null || filesToDownload.isNotEmpty() || projectId != null) {
       appendln("flank:")
     }
     testShards?.let {
       appendln("  max-test-shards: $testShards")
+    }
+    shardTime?.let {
+      appendln("  shard-time: $shardTime")
     }
     repeatTests?.let {
       appendln("  repeat-tests: $repeatTests")

--- a/buildSrc/src/test/java/com/osacky/flank/gradle/YamlWriterTest.kt
+++ b/buildSrc/src/test/java/com/osacky/flank/gradle/YamlWriterTest.kt
@@ -138,6 +138,16 @@ class YamlWriterTest {
   }
 
   @Test
+  fun writeShardTimeOption() {
+    val extension = FlankGradleExtension(project).apply {
+      shardTime = 120
+    }
+
+    assertEquals("flank:\n" +
+            "  shard-time: 120\n", yamlWriter.writeFlankProperties(extension))
+  }
+
+  @Test
   fun writeNoTestRepeats() {
     val extension = FlankGradleExtension(project).apply {
       repeatTests = null


### PR DESCRIPTION
While shardTime is present in the gradle plugin's configuration properties, it is not supported in FlankGradleExtension or YamlWriter. It will not be written to flank.yml properly as shard-time
This prevents the ability to use shardTime to dynamically set the shardCount.