### PR TITLE
Allow serviceAccountCredentials to be set using environment variables.

### DIFF
--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradlePlugin.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradlePlugin.kt
@@ -84,7 +84,9 @@ class FlankGradlePlugin : Plugin<Project> {
       classpath = project.fladleConfig
       main = "ftl.Main"
       args = listOf("firebase", "test", "android", "run")
-      environment(mapOf("GOOGLE_APPLICATION_CREDENTIALS" to "${config.serviceAccountCredentials}"))
+      if (config.serviceAccountCredentials != null) {
+        environment(mapOf("GOOGLE_APPLICATION_CREDENTIALS" to "${config.serviceAccountCredentials}"))
+      }
       dependsOn(named("writeConfigProps$name"))
       doFirst {
         checkFilesExist(base, project)
@@ -97,7 +99,9 @@ class FlankGradlePlugin : Plugin<Project> {
   }
 
   private fun checkFilesExist(base: FlankGradleExtension, project: Project) {
-    check(project.file(base.serviceAccountCredentials!!).exists()) { "serviceAccountCredential file doesn't exist ${base.serviceAccountCredentials}" }
+    if (base.serviceAccountCredentials != null) {
+      check(project.file(base.serviceAccountCredentials!!).exists()) { "serviceAccountCredential file doesn't exist ${base.serviceAccountCredentials}" }
+    }
     check(project.file(base.debugApk!!).exists()) { "debugApk file doesn't exist ${base.debugApk}" }
     check(project.file(base.instrumentationApk!!).exists()) { "instrumentationApk file doesn't exist ${base.instrumentationApk}" }
   }

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/YamlWriter.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/YamlWriter.kt
@@ -5,7 +5,9 @@ import org.gradle.internal.impldep.com.google.common.annotations.VisibleForTesti
 internal class YamlWriter {
 
   internal fun createConfigProps(config: FladleConfig, base: FlankGradleExtension): String {
-    checkNotNull(base.serviceAccountCredentials) { "ServiceAccountCredentials in fladle extension not set. https://github.com/runningcode/fladle#serviceaccountcredentials" }
+    if (base.projectId == null) {
+      checkNotNull(base.serviceAccountCredentials) { "ServiceAccountCredentials in fladle extension not set. https://github.com/runningcode/fladle#serviceaccountcredentials" }
+    }
     checkNotNull(base.debugApk) { "debugApk cannot be null" }
     checkNotNull(base.instrumentationApk) { "instrumentationApk cannot be null" }
 

--- a/buildSrc/src/test/java/com/osacky/flank/gradle/YamlWriterTest.kt
+++ b/buildSrc/src/test/java/com/osacky/flank/gradle/YamlWriterTest.kt
@@ -83,6 +83,32 @@ class YamlWriterTest {
   }
 
   @Test
+  fun verifyMissingServiceDoesntThrowErrorIfProjectIdSet() {
+    val extension = FlankGradleExtension(project).apply {
+      projectId = "set"
+      debugApk = "path"
+      instrumentationApk = "instrument"
+    }
+    val yaml = yamlWriter.createConfigProps(extension, extension)
+    assertEquals("gcloud:\n" +
+        "  app: path\n" +
+        "  test: instrument\n" +
+        "  device:\n" +
+        "  - model: NexusLowRes\n" +
+        "    version: 28\n" +
+        "\n" +
+        "  use-orchestrator: false\n" +
+        "  auto-google-login: false\n" +
+        "  record-video: true\n" +
+        "  performance-metrics: true\n" +
+        "  timeout: 15m\n" +
+        "  flaky-test-attempts: 0\n" +
+        "\n" +
+        "flank:\n" +
+        "  project: set\n", yaml)
+  }
+
+  @Test
   fun verifyDebugApkThrowsError() {
     val extension = FlankGradleExtension(project).apply {
       serviceAccountCredentials = "fake.json"

--- a/buildSrc/src/test/java/com/osacky/flank/gradle/integration/FlankGradlePluginIntegrationTest.kt
+++ b/buildSrc/src/test/java/com/osacky/flank/gradle/integration/FlankGradlePluginIntegrationTest.kt
@@ -49,6 +49,27 @@ class FlankGradlePluginIntegrationTest {
             .build()
     }
 
+  @Test
+  fun testMissingServiceAccountWithProjectId() {
+    writeBuildGradle(
+        """plugins {
+             |  id "com.osacky.fladle"
+             |}
+             |
+             |fladle {
+             |  projectId = "foo-project"
+             |  debugApk = "foo"
+             |  instrumentationApk = "fakeInstrument.apk"
+             |}""".trimMargin()
+    )
+    GradleRunner.create()
+        .withProjectDir(testProjectRoot.root)
+        .withPluginClasspath()
+        .withGradleVersion("5.3.1")
+        .withArguments("printYml")
+        .build()
+  }
+
     @Test
     fun testMissingServiceAccountFailsBuild() {
         writeBuildGradle(

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -22,6 +22,8 @@ android {
 
 fladle {
     serviceAccountCredentials("${project.file("flank-gradle-5cf02dc90531.json")}")
+    // Project Id is not needed if serviceAccountCredentials are set.
+//    projectId("flank-gradle")
     useOrchestrator = true
     environmentVariables = [
             "clearPackageData": "true"


### PR DESCRIPTION
This means that the project id must be set beforehand.

Fixes #55