### PR TITLE
Add secondary device constructor to select Android beta versions

### DIFF
--- a/buildSrc/src/main/java/com/osacky/flank/gradle/Device.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/Device.kt
@@ -1,3 +1,6 @@
 package com.osacky.flank.gradle
 
-data class Device(val model: String, val version: Int, val orientation: String? = null, val locale: String? = null)
+data class Device(val model: String, val version: String, val orientation: String? = null, val locale: String? = null) {
+    constructor(model: String, version: Int, orientation: String? = null, locale: String? = null) :
+            this(model, "$version", orientation, locale)
+}

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/Device.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/Device.kt
@@ -1,6 +1,14 @@
 package com.osacky.flank.gradle
 
+/*
+ * The version is a String so also unreleased Android versions can be specified. (e.g. Q-beta-3)
+ */
 data class Device(val model: String, val version: String, val orientation: String? = null, val locale: String? = null) {
+
+    /*
+     * Additional constructor for backwards compatibility, so Android versions can both be
+     * specified as a Int (most common case) and as a String.
+     */
     constructor(model: String, version: Int, orientation: String? = null, locale: String? = null) :
             this(model, "$version", orientation, locale)
 }


### PR DESCRIPTION
Firebase already allows to run tests on beta versions of Android Q.
E.g. The Pixel 3 (blueline) can run tests on "Q-beta-3"

```
$ gcloud firebase test android models list
┌───────────────────┬────────────────────┬─────────────────────────────────────┬──────────┬─────────────┬───────────────────┬───────────────┐
│      MODEL_ID     │        MAKE        │              MODEL_NAME             │   FORM   │  RESOLUTION │   OS_VERSION_IDS  │      TAGS     │
├───────────────────┼────────────────────┼─────────────────────────────────────┼──────────┼─────────────┼───────────────────┼───────────────┤
│ Pixel2            │ Google             │ Pixel 2                             │ VIRTUAL  │ 1920 x 1080 │ 26,27,28          │               │
│ a5y17lte          │ Samsung            │ Galaxy A5 2017                      │ PHYSICAL │ 1920 x 1080 │ 24                │               │
│ athene            │ Motorola           │ Moto G4 Plus                        │ PHYSICAL │ 1920 x 1080 │ 23                │               │
│ athene_f          │ Motorola           │ Moto G4                             │ PHYSICAL │ 1920 x 1080 │ 23                │               │
│ blueline          │ Google             │ Pixel 3                             │ PHYSICAL │ 2160 x 1080 │ 28,Q-beta-3       │               │
│ cheryl            │ Razer              │ Razer Phone                         │ PHYSICAL │ 2560 x 1440 │ 25                │               │
│ crownqlteue       │ Samsung            │ Galaxy Note 9 USA                   │ PHYSICAL │ 2220 x 1080 │ 27                │               │
```

Unfortunately currently that cannot be configured using Fladle as the Device class only has a constructor that takes a Android version Int.

I propose to change the device data class to take a String Android version, but to add a secondary constructor that still takes the Int data type in order not to break the current API.

Didn't add any unit tests as this is merely a change to the data class, but verified the sample tests on Firebase using:

```
devices = [
            new Device("blueline", "Q-beta-3", null, null)
    ]
```

And also manually verified the generated Flank file:

```
gcloud:
  app: /Users/jeroen/temp/fladle/sample/build/outputs/apk/debug/sample-debug.apk
  test: /Users/jeroen/temp/fladle/sample/build/outputs/apk/androidTest/debug/sample-debug-androidTest.apk
  device:
  - model: blueline
    version: Q-beta-3

  use-orchestrator: true
  auto-google-login: false
  record-video: true
  performance-metrics: true
  timeout: 15m
  environment-variables:
    clearPackageData: true
  test-targets:
  - class com.osacky.flank.gradle.sample.ExampleInstrumentedTest#seeView
  flaky-test-attempts: 1

flank:
  smart-flank-gcs-path: redacted
```