### PR TITLE
Add support for `results-bucket` gcloud config option

### DIFF
--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FladleConfig.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FladleConfig.kt
@@ -42,4 +42,6 @@ interface FladleConfig {
 
   // The number of times to retry failed tests. Default is 0. Max is 10.
   var flakyTestAttempts: Int
+
+  var resultsBucket: String?
 }

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FladleConfigImpl.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FladleConfigImpl.kt
@@ -20,5 +20,6 @@ data class FladleConfigImpl(
   override var environmentVariables: Map<String, String> = emptyMap(),
   override var timeoutMin: Int = 15,
   override var recordVideo: Boolean = true,
-  override var performanceMetrics: Boolean = true
+  override var performanceMetrics: Boolean = true,
+  override var resultsBucket: String? = null
 ) : FladleConfig

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
@@ -45,6 +45,8 @@ open class FlankGradleExtension(project: Project) : FladleConfig {
 
   override var performanceMetrics: Boolean = true
 
+  override var resultsBucket: String? = null
+
   val configs: NamedDomainObjectContainer<FladleConfigImpl> = project.container(FladleConfigImpl::class.java) {
     FladleConfigImpl(
       name = it,
@@ -66,7 +68,8 @@ open class FlankGradleExtension(project: Project) : FladleConfig {
       environmentVariables = environmentVariables,
       timeoutMin = timeoutMin,
       recordVideo = recordVideo,
-      performanceMetrics = performanceMetrics
+      performanceMetrics = performanceMetrics,
+      resultsBucket = resultsBucket
     )
   }
 

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/YamlWriter.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/YamlWriter.kt
@@ -66,6 +66,9 @@ internal class YamlWriter {
     config.resultsHistoryName?.let {
       appendln("  results-history-name: $it")
     }
+    config.resultsBucket?.let {
+      appendln("  results-bucket: $it")
+    }
     val environmentVariables = config.environmentVariables
     if (environmentVariables.isNotEmpty()) {
       appendln("  environment-variables:")

--- a/buildSrc/src/test/java/com/osacky/flank/gradle/YamlWriterTest.kt
+++ b/buildSrc/src/test/java/com/osacky/flank/gradle/YamlWriterTest.kt
@@ -221,6 +221,22 @@ class YamlWriterTest {
   }
 
   @Test
+  fun writeResultsBucket() {
+    val extension = FlankGradleExtension(project).apply {
+      resultsBucket = "fake-project.appspot.com"
+    }
+
+    assertEquals("  use-orchestrator: false\n" +
+        "  auto-google-login: false\n" +
+        "  record-video: true\n" +
+        "  performance-metrics: true\n" +
+        "  timeout: 15m\n" +
+        "  results-bucket: fake-project.appspot.com\n" +
+        "  flaky-test-attempts: 0\n",
+        yamlWriter.writeAdditionalProperties(extension))
+  }
+
+  @Test
   fun writeTestTargetsAndResultsHistoryName() {
     val extension = FlankGradleExtension(project).apply {
       resultsHistoryName = "androidtest"


### PR DESCRIPTION
Allows the user to specify a custom result-bucket url via the resultsBucket property in Fladle config