### PR TITLE
Allow wildcards in directory names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+
+## 0.6.7
+* Allow using wildcards in debugApk or instrumentationApk path by not checking that file exists.
+
 ## 0.6.6
 * Bump flank version to 7.0.0
 * Publish to mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,8 @@ buildscript {
 }
 
 plugins {
-    id "com.github.ben-manes.versions" version "0.22.0"
-    id 'com.gradle.build-scan' version '2.4.1'
+    id "com.github.ben-manes.versions" version "0.25.0"
+    id 'com.gradle.build-scan' version '2.4.2'
 }
 
 allprojects {
@@ -39,5 +39,5 @@ buildScan {
 
 wrapper {
     distributionType = Wrapper.DistributionType.ALL
-    gradleVersion = '5.6'
+    gradleVersion = '5.6.2'
 }

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradlePlugin.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradlePlugin.kt
@@ -102,8 +102,8 @@ class FlankGradlePlugin : Plugin<Project> {
     if (base.serviceAccountCredentials != null) {
       check(project.file(base.serviceAccountCredentials!!).exists()) { "serviceAccountCredential file doesn't exist ${base.serviceAccountCredentials}" }
     }
-    check(project.file(base.debugApk!!).exists()) { "debugApk file doesn't exist ${base.debugApk}" }
-    check(project.file(base.instrumentationApk!!).exists()) { "instrumentationApk file doesn't exist ${base.instrumentationApk}" }
+    checkNotNull(base.debugApk!!) { "debugApk file cannot be null ${base.debugApk}" }
+    checkNotNull(base.instrumentationApk!!) { "instrumentationApk file cannot be null ${base.instrumentationApk}" }
   }
 
   private fun automaticallyConfigureTestOrchestrator(project: Project, extension: FlankGradleExtension, androidExtension: AppExtension) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -50,7 +50,7 @@ fladle {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.0.2'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation('android.arch.navigation:navigation-fragment-ktx:1.0.0'){
         exclude group: 'com.android.support'
     }


### PR DESCRIPTION
This removes the check that the file exists. This also means that if the
file doesn't exist, flank may file with a weird cryptic error.

Fixes #71