### PR TITLE
Support Flank 8.x.x

### DIFF
--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
@@ -5,7 +5,7 @@ import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 
 open class FlankGradleExtension(project: Project) : FladleConfig {
-  override var flankVersion: String = "7.0.2"
+  override var flankVersion: String = "8.0.1"
   // Project id is automatically discovered by default. Use this to override the project id.
   override var projectId: String? = null
   override var serviceAccountCredentials: String? = null

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/YamlWriter.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/YamlWriter.kt
@@ -1,7 +1,7 @@
 package com.osacky.flank.gradle
 
-import org.gradle.api.GradleException
 import org.gradle.internal.impldep.com.google.common.annotations.VisibleForTesting
+import org.gradle.util.VersionNumber
 
 internal class YamlWriter {
 
@@ -120,18 +120,6 @@ internal class YamlWriter {
   }
 
   private fun isFlankVersionAtLeast(flankVersion: String, major: Int): Boolean {
-    val matchResult = FLANK_VERSION_REGEX.matchEntire(flankVersion)
-        ?: throw GradleException("Unsupported flank version $flankVersion")
-
-    if (matchResult.groupValues.size <= 1) throw GradleException("Unsupported flank version $flankVersion")
-
-    val actualMajorVersion = matchResult.groupValues[1].toIntOrNull()
-        ?: throw GradleException("Unsupported flank version $flankVersion")
-
-    return actualMajorVersion >= major
-  }
-
-  companion object {
-    private val FLANK_VERSION_REGEX = Regex("(\\d+)\\.\\d+\\.\\d+.*")
+    return VersionNumber.parse(flankVersion).major >= major
   }
 }

--- a/buildSrc/src/test/java/com/osacky/flank/gradle/MultipleConfigsTest.kt
+++ b/buildSrc/src/test/java/com/osacky/flank/gradle/MultipleConfigsTest.kt
@@ -54,7 +54,7 @@ class MultipleConfigsTest {
       |  timeout: 15m
       |  test-targets:
       |  - override
-      |  flaky-test-attempts: 0
+      |  num-flaky-test-attempts: 0
     """.trimMargin())
   }
 }

--- a/buildSrc/src/test/java/com/osacky/flank/gradle/YamlWriterTest.kt
+++ b/buildSrc/src/test/java/com/osacky/flank/gradle/YamlWriterTest.kt
@@ -102,7 +102,7 @@ class YamlWriterTest {
         "  record-video: true\n" +
         "  performance-metrics: true\n" +
         "  timeout: 15m\n" +
-        "  flaky-test-attempts: 0\n" +
+        "  num-flaky-test-attempts: 0\n" +
         "\n" +
         "flank:\n" +
         "  project: set\n", yaml)
@@ -189,7 +189,7 @@ class YamlWriterTest {
     }
 
     assertEquals("flank:\n" +
-        "  repeat-tests: 5\n", yamlWriter.writeFlankProperties(extension))
+        "  num-test-runs: 5\n", yamlWriter.writeFlankProperties(extension))
   }
 
   @Test
@@ -201,7 +201,7 @@ class YamlWriterTest {
 
     assertEquals("flank:\n" +
         "  max-test-shards: 5\n" +
-        "  repeat-tests: 2\n", yamlWriter.writeFlankProperties(extension))
+        "  num-test-runs: 2\n", yamlWriter.writeFlankProperties(extension))
   }
 
   @Test
@@ -216,7 +216,7 @@ class YamlWriterTest {
         "  performance-metrics: true\n" +
         "  timeout: 15m\n" +
         "  results-history-name: androidtest\n" +
-        "  flaky-test-attempts: 0\n",
+        "  num-flaky-test-attempts: 0\n",
         yamlWriter.writeAdditionalProperties(extension))
   }
 
@@ -232,7 +232,7 @@ class YamlWriterTest {
         "  performance-metrics: true\n" +
         "  timeout: 15m\n" +
         "  results-bucket: fake-project.appspot.com\n" +
-        "  flaky-test-attempts: 0\n",
+        "  num-flaky-test-attempts: 0\n",
         yamlWriter.writeAdditionalProperties(extension))
   }
 
@@ -251,7 +251,7 @@ class YamlWriterTest {
         "  results-history-name: androidtest\n" +
         "  test-targets:\n" +
         "  - class com.example.Foo\n" +
-        "  flaky-test-attempts: 0\n",
+        "  num-flaky-test-attempts: 0\n",
         yamlWriter.writeAdditionalProperties(extension))
   }
 
@@ -266,7 +266,7 @@ class YamlWriterTest {
         "  record-video: true\n" +
         "  performance-metrics: true\n" +
         "  timeout: 15m\n" +
-        "  flaky-test-attempts: 0\n", yamlWriter.writeAdditionalProperties(extension))
+        "  num-flaky-test-attempts: 0\n", yamlWriter.writeAdditionalProperties(extension))
   }
 
   @Test
@@ -282,7 +282,7 @@ class YamlWriterTest {
         "  timeout: 15m\n" +
         "  test-targets:\n" +
         "  - class com.example.Foo#testThing\n" +
-        "  flaky-test-attempts: 0\n",
+        "  num-flaky-test-attempts: 0\n",
         yamlWriter.writeAdditionalProperties(extension))
   }
 
@@ -300,7 +300,7 @@ class YamlWriterTest {
         "  test-targets:\n" +
         "  - class com.example.Foo#testThing\n" +
         "  - class com.example.Foo#testThing2\n" +
-        "  flaky-test-attempts: 0\n",
+        "  num-flaky-test-attempts: 0\n",
       yamlWriter.writeAdditionalProperties(extension))
   }
 
@@ -326,7 +326,7 @@ class YamlWriterTest {
         "  record-video: true\n" +
         "  performance-metrics: true\n" +
         "  timeout: 15m\n" +
-        "  flaky-test-attempts: 0\n", yamlWriter.writeAdditionalProperties(extension))
+        "  num-flaky-test-attempts: 0\n", yamlWriter.writeAdditionalProperties(extension))
   }
 
   @Test
@@ -342,7 +342,7 @@ class YamlWriterTest {
         "  timeout: 15m\n" +
         "  directories-to-pull:\n" +
         "  - /sdcard/screenshots\n" +
-        "  flaky-test-attempts: 0\n",
+        "  num-flaky-test-attempts: 0\n",
       yamlWriter.writeAdditionalProperties(extension))
   }
 
@@ -360,7 +360,7 @@ class YamlWriterTest {
         "  directories-to-pull:\n" +
         "  - /sdcard/screenshots\n" +
         "  - /sdcard/reports\n" +
-        "  flaky-test-attempts: 0\n",
+        "  num-flaky-test-attempts: 0\n",
       yamlWriter.writeAdditionalProperties(extension))
   }
 
@@ -413,7 +413,7 @@ class YamlWriterTest {
         "  timeout: 15m\n" +
         "  environment-variables:\n" +
         "    listener: com.osacky.flank.sample.Listener\n" +
-        "  flaky-test-attempts: 0\n",
+        "  num-flaky-test-attempts: 0\n",
       yamlWriter.writeAdditionalProperties(extension))
   }
 
@@ -434,7 +434,7 @@ class YamlWriterTest {
         "  environment-variables:\n" +
         "    clearPackageData: true\n" +
         "    listener: com.osacky.flank.sample.Listener\n" +
-        "  flaky-test-attempts: 0\n",
+        "  num-flaky-test-attempts: 0\n",
       yamlWriter.writeAdditionalProperties(extension))
   }
 
@@ -453,7 +453,7 @@ class YamlWriterTest {
         "  record-video: false\n" +
         "  performance-metrics: false\n" +
         "  timeout: 45m\n" +
-        "  flaky-test-attempts: 0\n",
+        "  num-flaky-test-attempts: 0\n",
       yamlWriter.writeAdditionalProperties(extension))
   }
 }

--- a/buildSrc/src/test/java/com/osacky/flank/gradle/YamlWriterTest.kt
+++ b/buildSrc/src/test/java/com/osacky/flank/gradle/YamlWriterTest.kt
@@ -193,6 +193,17 @@ class YamlWriterTest {
   }
 
   @Test
+  fun writeTestRepeatsForOlderFlankVersions() {
+    val extension = FlankGradleExtension(project).apply {
+      flankVersion = "7.0.2"
+      repeatTests = 5
+    }
+
+    assertEquals("flank:\n" +
+        "  repeat-tests: 5\n", yamlWriter.writeFlankProperties(extension))
+  }
+
+  @Test
   fun writeTestShardAndRepeatOption() {
     val extension = FlankGradleExtension(project).apply {
       testShards = 5
@@ -454,6 +465,21 @@ class YamlWriterTest {
         "  performance-metrics: false\n" +
         "  timeout: 45m\n" +
         "  num-flaky-test-attempts: 0\n",
+      yamlWriter.writeAdditionalProperties(extension))
+  }
+
+  @Test
+  fun writeFlakyTestAttemptsForOldFlankVersion() {
+    val extension = FlankGradleExtension(project).apply {
+      flankVersion = "7.0.2"
+      flakyTestAttempts = 3
+    }
+    assertEquals("  use-orchestrator: false\n" +
+        "  auto-google-login: false\n" +
+        "  record-video: true\n" +
+        "  performance-metrics: true\n" +
+        "  timeout: 15m\n" +
+        "  flaky-test-attempts: 3\n",
       yamlWriter.writeAdditionalProperties(extension))
   }
 }


### PR DESCRIPTION
[Flank 8.0.0](https://github.com/TestArmada/flank/releases/tag/v8.0.0) added two breaking changes.
- `flaky-test-attempts` has been renamed to `num-flaky-test-attempts`
- `repeat-tests` has been renamed to `num-test-runs`

This PR adds support for Flank 8 maintaining support for older Flank's versions at the same time.