### PR TITLE
Support flank version 8.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ fladle {
         }
     }
     resultsBucket("my-results-bucket-name")
+    keepFilePath = true
 }
 ```
 
@@ -172,6 +173,9 @@ Monitor and record performance metrics: CPU, memory, network usage, and FPS (gam
 
 ### resultsBucket
 The name of a Google Cloud Storage bucket where raw test results will be stored.
+
+### keepFilePath
+Keeps the full path of downloaded files from a Google Cloud Storage bucket. Required when file names are not unique. Disabled by default.
 
 ---
 ### Error APK file not found

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FladleConfig.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FladleConfig.kt
@@ -44,4 +44,6 @@ interface FladleConfig {
   var flakyTestAttempts: Int
 
   var resultsBucket: String?
+
+  var keepFilePath: Boolean
 }

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FladleConfigImpl.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FladleConfigImpl.kt
@@ -21,5 +21,6 @@ data class FladleConfigImpl(
   override var timeoutMin: Int = 15,
   override var recordVideo: Boolean = true,
   override var performanceMetrics: Boolean = true,
-  override var resultsBucket: String? = null
+  override var resultsBucket: String? = null,
+  override var keepFilePath: Boolean = false
 ) : FladleConfig

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
@@ -5,7 +5,7 @@ import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 
 open class FlankGradleExtension(project: Project) : FladleConfig {
-  override var flankVersion: String = "8.0.1"
+  override var flankVersion: String = "8.1.0"
   // Project id is automatically discovered by default. Use this to override the project id.
   override var projectId: String? = null
   override var serviceAccountCredentials: String? = null
@@ -47,6 +47,8 @@ open class FlankGradleExtension(project: Project) : FladleConfig {
 
   override var resultsBucket: String? = null
 
+  override var keepFilePath: Boolean = false
+
   val configs: NamedDomainObjectContainer<FladleConfigImpl> = project.container(FladleConfigImpl::class.java) {
     FladleConfigImpl(
       name = it,
@@ -69,7 +71,8 @@ open class FlankGradleExtension(project: Project) : FladleConfig {
       timeoutMin = timeoutMin,
       recordVideo = recordVideo,
       performanceMetrics = performanceMetrics,
-      resultsBucket = resultsBucket
+      resultsBucket = resultsBucket,
+      keepFilePath = keepFilePath
     )
   }
 

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/YamlWriter.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/YamlWriter.kt
@@ -31,9 +31,9 @@ internal class YamlWriter {
     val smartFlankGcsPath = config.smartFlankGcsPath
     val filesToDownload = config.filesToDownload
     val projectId = config.projectId
-    if (testShards != null || shardTime != null || repeatTests != null || smartFlankGcsPath != null || filesToDownload.isNotEmpty() || projectId != null) {
-      appendln("flank:")
-    }
+
+    appendln("flank:")
+
     testShards?.let {
       appendln("  max-test-shards: $testShards")
     }
@@ -49,6 +49,7 @@ internal class YamlWriter {
     projectId?.let {
       appendln("  project: $it")
     }
+    appendln("  keep-file-path: ${config.keepFilePath}")
     if (filesToDownload.isNotEmpty()) {
       appendln("  files-to-download:")
       filesToDownload.forEach { file ->

--- a/buildSrc/src/test/java/com/osacky/flank/gradle/MultipleConfigsTest.kt
+++ b/buildSrc/src/test/java/com/osacky/flank/gradle/MultipleConfigsTest.kt
@@ -55,6 +55,7 @@ class MultipleConfigsTest {
       |  test-targets:
       |  - override
       |  num-flaky-test-attempts: 0
+      |
       |flank:
       |  keep-file-path: false
     """.trimMargin())

--- a/buildSrc/src/test/java/com/osacky/flank/gradle/MultipleConfigsTest.kt
+++ b/buildSrc/src/test/java/com/osacky/flank/gradle/MultipleConfigsTest.kt
@@ -55,6 +55,8 @@ class MultipleConfigsTest {
       |  test-targets:
       |  - override
       |  num-flaky-test-attempts: 0
+      |flank:
+      |  keep-file-path: false
     """.trimMargin())
   }
 }

--- a/buildSrc/src/test/java/com/osacky/flank/gradle/YamlWriterTest.kt
+++ b/buildSrc/src/test/java/com/osacky/flank/gradle/YamlWriterTest.kt
@@ -500,4 +500,24 @@ class YamlWriterTest {
         "  flaky-test-attempts: 3\n",
       yamlWriter.writeAdditionalProperties(extension))
   }
+
+  @Test
+  fun writeNoKeepFilePath() {
+    val extension = FlankGradleExtension(project)
+
+    assertEquals("flank:\n" +
+        "  keep-file-path: false\n",
+      yamlWriter.writeFlankProperties(extension))
+  }
+
+  @Test
+  fun writeKeepFilePath() {
+    val extension = FlankGradleExtension(project).apply {
+      keepFilePath = true
+    }
+
+    assertEquals("flank:\n" +
+        "  keep-file-path: true\n",
+      yamlWriter.writeFlankProperties(extension))
+  }
 }

--- a/buildSrc/src/test/java/com/osacky/flank/gradle/YamlWriterTest.kt
+++ b/buildSrc/src/test/java/com/osacky/flank/gradle/YamlWriterTest.kt
@@ -105,7 +105,8 @@ class YamlWriterTest {
         "  num-flaky-test-attempts: 0\n" +
         "\n" +
         "flank:\n" +
-        "  project: set\n", yaml)
+        "  project: set\n" +
+        "  keep-file-path: false\n", yaml)
   }
 
   @Test
@@ -140,7 +141,9 @@ class YamlWriterTest {
     val extension = FlankGradleExtension(project).apply {
     }
 
-    assertEquals("", yamlWriter.writeFlankProperties(extension))
+    assertEquals("flank:\n" +
+        "  keep-file-path: false\n",
+      yamlWriter.writeFlankProperties(extension))
   }
 
   @Test
@@ -150,7 +153,9 @@ class YamlWriterTest {
     }
 
     assertEquals("flank:\n" +
-        "  project: foo\n", yamlWriter.writeFlankProperties(extension))
+        "  project: foo\n" +
+        "  keep-file-path: false\n",
+      yamlWriter.writeFlankProperties(extension))
   }
 
   @Test
@@ -160,7 +165,8 @@ class YamlWriterTest {
     }
 
     assertEquals("flank:\n" +
-        "  max-test-shards: 5\n", yamlWriter.writeFlankProperties(extension))
+        "  max-test-shards: 5\n" +
+        "  keep-file-path: false\n", yamlWriter.writeFlankProperties(extension))
   }
 
   @Test
@@ -170,7 +176,9 @@ class YamlWriterTest {
     }
 
     assertEquals("flank:\n" +
-            "  shard-time: 120\n", yamlWriter.writeFlankProperties(extension))
+        "  shard-time: 120\n" +
+        "  keep-file-path: false\n",
+      yamlWriter.writeFlankProperties(extension))
   }
 
   @Test
@@ -179,7 +187,9 @@ class YamlWriterTest {
       repeatTests = null
     }
 
-    assertEquals("", yamlWriter.writeFlankProperties(extension))
+    assertEquals("flank:\n" +
+        "  keep-file-path: false\n",
+      yamlWriter.writeFlankProperties(extension))
   }
 
   @Test
@@ -189,7 +199,8 @@ class YamlWriterTest {
     }
 
     assertEquals("flank:\n" +
-        "  num-test-runs: 5\n", yamlWriter.writeFlankProperties(extension))
+        "  num-test-runs: 5\n" +
+        "  keep-file-path: false\n", yamlWriter.writeFlankProperties(extension))
   }
 
   @Test
@@ -200,7 +211,8 @@ class YamlWriterTest {
     }
 
     assertEquals("flank:\n" +
-        "  repeat-tests: 5\n", yamlWriter.writeFlankProperties(extension))
+        "  repeat-tests: 5\n" +
+        "  keep-file-path: false\n", yamlWriter.writeFlankProperties(extension))
   }
 
   @Test
@@ -212,7 +224,8 @@ class YamlWriterTest {
 
     assertEquals("flank:\n" +
         "  max-test-shards: 5\n" +
-        "  num-test-runs: 2\n", yamlWriter.writeFlankProperties(extension))
+        "  num-test-runs: 2\n" +
+        "  keep-file-path: false\n", yamlWriter.writeFlankProperties(extension))
   }
 
   @Test
@@ -322,7 +335,8 @@ class YamlWriterTest {
     }
 
     assertEquals("flank:\n" +
-        "  smart-flank-gcs-path: gs://test/fakepath.xml\n",
+        "  smart-flank-gcs-path: gs://test/fakepath.xml\n" +
+        "  keep-file-path: false\n",
         yamlWriter.writeFlankProperties(extension))
   }
 
@@ -381,7 +395,9 @@ class YamlWriterTest {
       filesToDownload = listOf()
     }
 
-    assertEquals("", yamlWriter.writeFlankProperties(extension))
+    assertEquals("flank:\n" +
+        "  keep-file-path: false\n",
+      yamlWriter.writeFlankProperties(extension))
   }
 
   @Test
@@ -391,6 +407,7 @@ class YamlWriterTest {
     }
 
     assertEquals("flank:\n" +
+        "  keep-file-path: false\n" +
         "  files-to-download:\n" +
         "  - .*/screenshots/.*\n",
       yamlWriter.writeFlankProperties(extension))
@@ -403,6 +420,7 @@ class YamlWriterTest {
     }
 
     assertEquals("flank:\n" +
+        "  keep-file-path: false\n" +
         "  files-to-download:\n" +
         "  - .*/screenshots/.*\n" +
         "  - .*/reports/.*\n",


### PR DESCRIPTION
Add new feature from flank version 8.1.0.
`keep-file-path`
Keeps the full path of downloaded files from a Google Cloud Storage bucket. Required when file names are not unique. Disabled by default.