### PR TITLE
Allow specifying custom coordinates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.9.0
+* Do not add flank maven repo.
+* Allow specifying custom flank coordinates.
 
 ## 0.8.1
 * Add support for `additionalTestApks`. [PR](https://github.com/runningcode/fladle/pull/83) Thanks [japplin](https://github.com/japplin).

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ buildscript {
   }
 }
 
+repositories {
+  maven { url 'https://dl.bintray.com/flank/maven' }
+}
+
 apply plugin: "com.osacky.fladle"
 ```
 2. Configure the Fladle extension.
@@ -76,7 +80,7 @@ fladle {
         [ "model": "Nexus5", "version": "23" ]
     ]
     projectId("flank-gradle")
-    flankVersion("4.4.0")
+    flankVersion("8.1.0")
     debugApk("$buildDir/outputs/apk/debug/sample-debug.apk")
     instrumentationApk("$buildDir/outputs/apk/androidTest/debug/sample-debug-androidTest.apk")
     additionalTestApks = ["$buildDir/outputs/apk/debug/sample-debug.apk": ["$buildDir/outputs/apk/androidTest/debug/sample2-debug-androidTest.apk"]]
@@ -116,8 +120,10 @@ This is automatically discovered based on the service credential by default.
 ### flankVersion
 `flankVersion("flank_snapshot")` to specify a Flank snapshot.
 
-`flankVersion("4.4.0")` to specify a specific Flank version.
+`flankVersion("8.1.0")` to specify a specific Flank version.
 
+### flankCoordinates
+`flankCoordinates("com.github.flank:flank")` to specify custom flank coordinates.
 
 ### debugApk
 This is the path to the app's debug apk.

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FladleConfig.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FladleConfig.kt
@@ -1,6 +1,7 @@
 package com.osacky.flank.gradle
 
 interface FladleConfig {
+  var flankCoordinates: String
   var flankVersion: String
   // Project id is automatically discovered by default. Use this to override the project id.
   var projectId: String?

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FladleConfigImpl.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FladleConfigImpl.kt
@@ -2,6 +2,7 @@ package com.osacky.flank.gradle
 
 data class FladleConfigImpl(
   internal val name: String,
+  override var flankCoordinates: String,
   override var flankVersion: String,
   override var projectId: String? = null,
   override var serviceAccountCredentials: String? = null,

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
@@ -5,6 +5,7 @@ import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 
 open class FlankGradleExtension(project: Project) : FladleConfig {
+  override var flankCoordinates: String = "flank:flank"
   override var flankVersion: String = "8.1.0"
   // Project id is automatically discovered by default. Use this to override the project id.
   override var projectId: String? = null
@@ -56,6 +57,7 @@ open class FlankGradleExtension(project: Project) : FladleConfig {
   val configs: NamedDomainObjectContainer<FladleConfigImpl> = project.container(FladleConfigImpl::class.java) {
     FladleConfigImpl(
       name = it,
+      flankCoordinates = flankCoordinates,
       flankVersion = flankVersion,
       projectId = projectId,
       serviceAccountCredentials = serviceAccountCredentials,

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradlePlugin.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradlePlugin.kt
@@ -8,17 +8,12 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.tasks.JavaExec
 import org.gradle.api.tasks.TaskContainer
-import org.gradle.kotlin.dsl.repositories
 import org.gradle.util.GradleVersion
 
 class FlankGradlePlugin : Plugin<Project> {
 
   override fun apply(target: Project) {
     checkMinimumGradleVersion()
-    // Add Flank maven repo.
-    target.repositories {
-      maven { url = target.uri("https://dl.bintray.com/flank/maven") }
-    }
 
     // Create Configuration to store flank dependency
     target.configurations.create(FLADLE_CONFIG)
@@ -38,7 +33,7 @@ class FlankGradlePlugin : Plugin<Project> {
   private fun configureTasks(project: Project, base: FlankGradleExtension) {
     project.afterEvaluate {
       // Add Flank dependency to Fladle Configuration
-      project.dependencies.add(FLADLE_CONFIG, "flank:flank:${base.flankVersion}")
+      project.dependencies.add(FLADLE_CONFIG, "${base.flankCoordinates}:${base.flankVersion}")
 
       // Only use automatic apk path detection for 'com.android.application' projects.
       project.pluginManager.withPlugin("com.android.application") {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -2,6 +2,10 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'com.osacky.fladle'
 
+repositories {
+    maven { url 'https://dl.bintray.com/flank/maven' }
+}
+
 android {
     compileSdkVersion 28
     buildToolsVersion "28.0.3"


### PR DESCRIPTION
The upcoming version of flank is changing its maven coordinates. This
will allow us to test upcoming versions of flank using the current
version of fladle.

Also removed adding bintray repo. Adding a custom repo is not a good
idea for companies that use their own maven proxy for stability and
security reasons. This should also be a win for build speeds
once flank is uploaded to maven central.