### PR TITLE
Documentation update

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
 
 plugins {
   `kotlin-dsl`
-  id("java-gradle-plugin")
+  `java-gradle-plugin`
   id("com.gradle.plugin-publish") version "0.11.0"
   id("org.jmailen.kotlinter") version "2.3.2"
   `maven-publish`
@@ -116,6 +116,6 @@ publishing {
 }
 
 signing {
-  setRequired(isReleaseBuild)
+  isRequired = isReleaseBuild
   sign(publishing.publications["mavenJava"])
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,13 +3,20 @@
 ## 0.9.2
 * Update [Flank to 20.05.0](https://github.com/Flank/flank/releases/tag/v20.05.0). Huge new release!
 * Add support for new flank flags. Thanks [pawelpasterz](https://github.com/pawelpasterz) [PR](https://github.com/runningcode/fladle/pull/88)
-* Breaking API change: debugApk and instrumentationApk now use Lazy Property API to avoid resolving at configuration time.
+
+!!! Warning  "Breaking API change"
+    debugApk and instrumentationApk now use Lazy Property API to avoid resolving at configuration time.
 
 ## 0.9.1
+
 * Bugfix: ability to set flank version. [PR](https://github.com/runningcode/fladle/pull/97)
-* Breaking API change: serviceAccountCredentials now uses [Lazy  Property API](https://docs.gradle.org/current/userguide/lazy_configuration.html#working_with_files_in_lazy_properties). See README for details on how to set it. [PR](https://github.com/runningcode/fladle/pull/97)
-* Minimum required Gradle Version is now 5.1.
-* Dropped support for Flank 7.X and lower.
+
+!!! Warning "Breaking API Change"
+    serviceAccountCredentials now uses [Lazy  Property API](https://docs.gradle.org/current/userguide/lazy_configuration.html#working_with_files_in_lazy_properties). See [Configuration](/configuration#serviceAccountCredentials) for details on how to set it. [PR](https://github.com/runningcode/fladle/pull/97)
+!!! Warning
+    Minimum required Gradle Version is now 5.1.
+!!! Warning
+    Dropped support for Flank 7.X and lower.
 
 ## 0.9.0
 * Do not add flank maven repo. [PR](https://github.com/runningcode/fladle/pull/94)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -12,3 +12,14 @@ afterEvaluate {
 ```
 
 See [https://issuetracker.google.com/issues/152240037]() for more information.
+
+
+## No signature of method
+If you receive an error like this, it is likely caused by invalid fladle extension confiuration.
+The syntax was changed in the `0.9.X` releases in order to avoid touching files during the configuration phase.
+```bash
+No signature of method: flank_4vvjv7w3oopge32w1tl9cs6e4.fladle() is applicable for argument types: (flank_4vvjv7w3oopge32w1tl9cs6e4$_run_closure1) values: [flank_4vvjv7w3oopge32w1tl9cs6e4$_run_closure1@649a2315]
+			Possible solutions: file(java.lang.Object), find(), findAll(), file(java.lang.Object, org.gradle.api.PathValidation), files([Ljava.lang.Object;), findAll(groovy.lang.Closure)
+```
+
+If you receive a similar error, please check [configuration](/configuration#sample-configuration) for a sample configuration.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -42,7 +42,7 @@ git push origin v{{ fladle.next_release }}
 ```
 * Upload to Maven Central
 ``` bash
-./gradlew -b buildSrc/build.gradle.kts publishMavenJavaPublicationToMavenRepository
+./gradlew -b buildSrc/build.gradle.kts publishMavenJavaPublicationToMavenRepository publishFladlePluginMarkerMavenPublicationToMavenRepository
 ```
 
 * Release to Maven Central

--- a/docs/snapshots.md
+++ b/docs/snapshots.md
@@ -1,0 +1,47 @@
+# Testing Snapshot Releases
+
+To test the Fladle snapshot release you have two options:
+
+
+# Traditional
+Root `build.gradle`
+```groovy
+
+buildscript {
+  repositories {
+    maven {
+      url "https://oss.sonatype.org/content/repositories/snapshots/"
+    }
+  }
+  dependencies {
+    classpath "com.osacky.flank.gradle:fladle:{{ fladle.next_release }}-SNAPSHOT"
+  }
+}
+```
+
+Project `build.gradle`
+```groovy
+apply plugin: "com.osacky.fladle"
+```
+
+
+
+# Plugin Management
+`settings.gradle`
+```groovy
+pluginManagement {
+    repositories {
+        maven {
+            url "https://oss.sonatype.org/content/repositories/snapshots/"
+        }
+        gradlePluginPortal()
+    }
+}
+```
+
+Android application `build.gradle`
+```groovy
+plugins {
+    id "com.osacky.fladle" version "{{ fladle.next_release }}-SNAPSHOT"
+}
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ nav:
   - Changelog: changelog.md
   - Results: results.md
   - FAQ: faq.md
+  - Testing Snapshots: snapshots.md
   - Releasing: releasing.md
 
 theme:


### PR DESCRIPTION
Add documentation for publishing plugin marker.
Add documentation on how to use snapshots.
Add documentation for build failures when upgrading to 0.9.X

Fixes #102, #103, #104