### PR TITLE
Add support for dumping shards.

### DIFF
--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradlePlugin.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradlePlugin.kt
@@ -84,7 +84,11 @@ class FlankGradlePlugin : Plugin<Project> {
       workingDir(project.fladleDir)
       classpath = project.fladleConfig
       main = "ftl.Main"
-      args = listOf("firebase", "test", "android", "run")
+      if (project.hasProperty("dumpShards")) {
+        args = listOf("firebase", "test", "android", "run", "--dump-shards")
+      } else {
+        args = listOf("firebase", "test", "android", "run")
+      }
       if (config.serviceAccountCredentials.isPresent) {
         environment(mapOf("GOOGLE_APPLICATION_CREDENTIALS" to config.serviceAccountCredentials.get()))
       }

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -23,3 +23,6 @@ No signature of method: flank_4vvjv7w3oopge32w1tl9cs6e4.fladle() is applicable f
 ```
 
 If you receive a similar error, please check [configuration](/configuration#sample-configuration) for a sample configuration.
+
+## Debugging
+`./gradlew runFlank -PdumpShards` Will dump shards and exit the process without running the tests.


### PR DESCRIPTION
Usage:
`./gradlew runFlank -PdumpShards`

Fixes #115