### PR TITLE
Allow specifying roboscript without specifying instrumenationApk.

### DIFF
--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FladlePluginDelegate.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FladlePluginDelegate.kt
@@ -107,8 +107,6 @@ class FladlePluginDelegate {
     if (base.serviceAccountCredentials.isPresent) {
       check(project.file(base.serviceAccountCredentials.get()).exists()) { "serviceAccountCredential file doesn't exist ${base.serviceAccountCredentials.get()}" }
     }
-    check(base.debugApk.isPresent) { "debugApk file must be specified ${base.debugApk.orNull}" }
-    check(base.instrumentationApk.isPresent) { "instrumentationApk file must be specified ${base.instrumentationApk.orNull}" }
   }
 
   private fun automaticallyConfigureTestOrchestrator(project: Project, extension: FlankGradleExtension, androidExtension: AppExtension) {

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/YamlWriter.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/YamlWriter.kt
@@ -9,7 +9,11 @@ internal class YamlWriter {
       check(base.serviceAccountCredentials.isPresent) { "ServiceAccountCredentials in fladle extension not set. https://github.com/runningcode/fladle#serviceaccountcredentials" }
     }
     check(base.debugApk.isPresent) { "debugApk must be specified" }
-    check(base.instrumentationApk.isPresent) { "instrumentationApk must be specified" }
+    check(base.instrumentationApk.isPresent xor !base.roboScript.isNullOrBlank()) { """
+     Either instrumentationApk file or roboScript file must be specified but not both.
+     instrumentationApk=${base.instrumentationApk.orNull}
+     roboScript=${base.roboScript}
+    """.trimIndent() }
 
     val deviceString = createDeviceString(config.devices)
     val additionalProperties = writeAdditionalProperties(config)

--- a/buildSrc/src/test/java/com/osacky/flank/gradle/YamlWriterTest.kt
+++ b/buildSrc/src/test/java/com/osacky/flank/gradle/YamlWriterTest.kt
@@ -177,7 +177,7 @@ class YamlWriterTest {
   }
 
   @Test
-  fun verifyInstrumentationApkThrowsError() {
+  fun verifyNoInstrumentationApkThrowsError() {
     val extension = emptyExtension {
       serviceAccountCredentials.set(project.layout.projectDirectory.file("fake.json"))
       debugApk.set("path")
@@ -186,7 +186,31 @@ class YamlWriterTest {
       yamlWriter.createConfigProps(extension, extension)
       fail()
     } catch (expected: IllegalStateException) {
-      assertEquals("instrumentationApk must be specified", expected.message)
+      assertThat(expected).hasMessageThat().isEqualTo("""
+        Either instrumentationApk file or roboScript file must be specified but not both.
+        instrumentationApk=null
+        roboScript=null
+      """.trimIndent())
+    }
+  }
+
+  @Test
+  fun verifyInstrumentationApkAndRoboscriptThrowsError() {
+    val extension = emptyExtension {
+      serviceAccountCredentials.set(project.layout.projectDirectory.file("fake.json"))
+      debugApk.set("path")
+      instrumentationApk.set("build/test/*.apk")
+      roboScript = "foo"
+    }
+    try {
+      yamlWriter.createConfigProps(extension, extension)
+      fail()
+    } catch (expected: IllegalStateException) {
+      assertThat(expected).hasMessageThat().isEqualTo("""
+        Either instrumentationApk file or roboScript file must be specified but not both.
+        instrumentationApk=build/test/*.apk
+        roboScript=foo
+      """.trimIndent())
     }
   }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.10.1
+* [Fix] Allow for specifying roboScript without specifying instrumentationApk. Fixes [#128](https://github.com/runningcode/fladle/issues/128).
+
 ## 0.10.0
 
 * Allow for debugging using [--dump-shards](/fladle/faq/#debugging)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -173,6 +173,7 @@ Optional, prefer to set [variant](/configuration#variant).
 This is a string representing the path to the app's instrumentaiton apk. 
 Supports wildcard characters. 
 Optional, prefer to set [variant](/configuration#variant).
+InstrumenationApk should not be set when using [roboScript](/configuration#roboscript).
 
 === "Groovy"
     ``` groovy


### PR DESCRIPTION
Either must be specified but not both.

Fixes #128