### PR TITLE
Don't automatically configure instrumentationApk when roboScript is set.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
             # fallback to using the latest cache if no exact match is found
             - v1-dependencies-
 
-      - run: ./gradlew assembleDebug assembleDebugAndroidTest printYml
+      - run: ./gradlew -I gradle/buildScanInit.gradle assembleDebug assembleDebugAndroidTest printYml
 
       - run:
           name: Save test results

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ flank-gradle-*.json
 
 # Mkdocs generated
 site
+
+# Pyhon Environment
+lib
+bin

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,11 @@ allprojects {
         google()
         mavenCentral()
         // jcenter is required for "org.jetbrains.trove4j:trove4j:20160824."
-        jcenter()
+        jcenter() {
+            content {
+                includeVersion 'org.jetbrains.trove4j', 'trove4j', '20160824'
+            }
+        }
     }
 }
 
@@ -43,4 +47,17 @@ buildScan {
 wrapper {
     distributionType = Wrapper.DistributionType.ALL
     gradleVersion = '6.4.1'
+}
+
+def isNonStable = { String version ->
+    def stableKeyword = ['RELEASE', 'FINAL', 'GA'].any { it -> version.toUpperCase().contains(it) }
+    def regex = /^[0-9,.v-]+(-r)?$/
+    return !stableKeyword && !(version ==~ regex)
+}
+
+dependencyUpdates {
+    // Example 1: reject all non stable versions
+    rejectVersionIf {
+        isNonStable(it.candidate.version)
+    }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.api.tasks.testing.logging.TestLogEvent
+
 group = "com.osacky.flank.gradle"
 version = "0.10.1-SNAPSHOT"
 description = "Easily Scale your Android Instrumentation Tests with Firebase Test Lab with Flank"
@@ -143,5 +145,11 @@ fun org.gradle.api.publish.maven.MavenPom.configureForFladle(pluginName: String)
     connection.set("scm:git:git://github.com/runningcode/fladle.git")
     developerConnection.set("scm:git:ssh://github.com/runningcode/fladle.git")
     url.set("https://github.com/runningcode/fladle")
+  }
+}
+
+tasks.withType(Test::class.java).configureEach {
+  testLogging {
+    events = setOf(TestLogEvent.SKIPPED, TestLogEvent.FAILED, TestLogEvent.PASSED)
   }
 }

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FladlePluginDelegate.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FladlePluginDelegate.kt
@@ -128,9 +128,11 @@ class FladlePluginDelegate {
         appVariant.outputs.configureEach app@{
           if (!extension.variant.isPresent || (extension.variant.isPresent && extension.variant.get() == appVariant.name)) {
             project.log("Configuring fladle.debugApk from variant ${this@app.name}")
-            project.log("Configuring fladle.instrumentationApk from variant ${this@test.name}")
             extension.debugApk.set(this@app.outputFile.absolutePath)
-            extension.instrumentationApk.set(this@test.outputFile.absolutePath)
+            if (extension.roboScript == null) {
+              project.log("Configuring fladle.instrumentationApk from variant ${this@test.name}")
+              extension.instrumentationApk.set(this@test.outputFile.absolutePath)
+            }
           }
         }
       }
@@ -141,7 +143,7 @@ class FladlePluginDelegate {
     get() = configurations.getByName(FLADLE_CONFIG)
 
   companion object {
-    val GRADLE_MIN_VERSION: GradleVersion = GradleVersion.version("5.4")
+    val GRADLE_MIN_VERSION: GradleVersion = GradleVersion.version("5.5")
     const val TASK_GROUP = "fladle"
     const val FLADLE_CONFIG = "fladle"
     fun Project.log(message: String) {

--- a/buildSrc/src/test/java/com/osacky/flank/gradle/integration/AndroidTestUtil.kt
+++ b/buildSrc/src/test/java/com/osacky/flank/gradle/integration/AndroidTestUtil.kt
@@ -1,0 +1,41 @@
+package com.osacky.flank.gradle.integration
+
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.io.File
+import java.util.Properties
+
+internal fun androidHome(): String {
+  val env = System.getenv("ANDROID_HOME")
+  if (env != null) {
+    return env.withInvariantPathSeparators()
+  }
+  val localProp = File(File(System.getProperty("user.dir")).parentFile, "local.properties")
+  if (localProp.exists()) {
+    val prop = Properties()
+    localProp.inputStream().use {
+      prop.load(it)
+    }
+    val sdkHome = prop.getProperty("sdk.dir")
+    if (sdkHome != null) {
+      return sdkHome.withInvariantPathSeparators()
+    }
+  }
+  throw IllegalStateException(
+      "Missing 'ANDROID_HOME' environment variable or local.properties with 'sdk.dir'")
+}
+
+internal fun String.withInvariantPathSeparators() = replace("\\", "/")

--- a/buildSrc/src/test/java/com/osacky/flank/gradle/integration/AutoConfigureFladleTest.kt
+++ b/buildSrc/src/test/java/com/osacky/flank/gradle/integration/AutoConfigureFladleTest.kt
@@ -1,0 +1,86 @@
+package com.osacky.flank.gradle.integration
+
+import com.google.common.truth.Truth.assertThat
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class AutoConfigureFladleTest {
+
+  @get:Rule
+  var testProjectRoot = TemporaryFolder()
+  fun writeBuildGradle(build: String) {
+    val file = testProjectRoot.newFile("build.gradle")
+    file.writeText(build)
+  }
+
+  @Test
+  fun testAndroidProject() {
+    val fixtureName = "android-project"
+    testProjectRoot.newFile("local.properties").writeText("sdk.dir=${androidHome()}\n")
+    testProjectRoot.newFile("gradle.properties").writeText("android.useAndroidX=true")
+    writeBuildGradle(
+        """
+            allprojects {
+              repositories {
+                google()
+                mavenCentral()
+                jcenter()
+              } 
+            }
+             """.trimIndent()
+    )
+      testProjectRoot.newFile("settings.gradle").writeText("""
+        pluginManagement {
+          repositories {
+            gradlePluginPortal()
+//            google()
+          }
+        }
+        include '$fixtureName'
+      """.trimIndent())
+
+    testProjectRoot.setupFixture(fixtureName)
+    testProjectRoot.root.walk().forEach {
+      println(it)
+    }
+
+    val result = GradleRunner.create()
+        .withProjectDir(testProjectRoot.root)
+        .withPluginClasspath()
+        .withArguments("assembleDebug", "assembleDebugAndroidTest", "printYml", "--stacktrace")
+        .build()
+
+    assertThat(result.output).contains("BUILD SUCCESSFUL")
+    assertThat(result.output).containsMatch("""
+        > Task :android-project:printYml
+        gcloud:
+          app: [0-9a-zA-Z\/]*/android-project/build/outputs/apk/debug/android-project-debug.apk
+          test: [0-9a-zA-Z\/]*/android-project/build/outputs/apk/androidTest/debug/android-project-debug-androidTest.apk
+          device:
+          - model: Pixel2
+            version: 26
+          - model: Nexus5
+            version: 23
+        
+          use-orchestrator: true
+          auto-google-login: false
+          record-video: true
+          performance-metrics: true
+          timeout: 15m
+          environment-variables:
+            clearPackageData: true
+          test-targets:
+          - class com.osacky.flank.gradle.sample.ExampleInstrumentedTest#seeView
+          num-flaky-test-attempts: 0
+        
+        flank:
+          smart-flank-gcs-path: gs://test-lab-yr9w6qsdvy45q-iurp80dm95h8a/flank/test_app_android.xml
+          keep-file-path: false
+          ignore-failed-tests: false
+          disable-sharding: false
+          smart-flank-disable-upload: false
+    """.trimIndent())
+  }
+}

--- a/buildSrc/src/test/java/com/osacky/flank/gradle/integration/FlankGradlePluginIntegrationTest.kt
+++ b/buildSrc/src/test/java/com/osacky/flank/gradle/integration/FlankGradlePluginIntegrationTest.kt
@@ -31,7 +31,7 @@ class FlankGradlePluginIntegrationTest {
         .withPluginClasspath()
         .withGradleVersion(oldVersion)
         .buildAndFail()
-    assertThat(result.output).contains("Fladle requires at minimum version Gradle 5.4. Detected version Gradle 5.3.1")
+    assertThat(result.output).contains("Fladle requires at minimum version Gradle 5.5. Detected version Gradle 5.3.1")
   }
 
   @Test

--- a/buildSrc/src/test/java/com/osacky/flank/gradle/integration/TestFixtures.kt
+++ b/buildSrc/src/test/java/com/osacky/flank/gradle/integration/TestFixtures.kt
@@ -1,0 +1,8 @@
+package com.osacky.flank.gradle.integration
+
+import java.io.File
+import org.junit.rules.TemporaryFolder
+
+fun TemporaryFolder.setupFixture(fixtureName: String) {
+    File(this::class.java.classLoader.getResource(fixtureName)!!.file).copyRecursively(newFile(fixtureName), true)
+}

--- a/buildSrc/src/test/resources/android-project/build.gradle
+++ b/buildSrc/src/test/resources/android-project/build.gradle
@@ -1,6 +1,7 @@
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply plugin: 'com.osacky.fladle'
+plugins {
+    id 'com.android.application'
+    id 'com.osacky.fladle'
+}
 
 android {
     compileSdkVersion 28
@@ -18,10 +19,7 @@ android {
 }
 
 fladle {
-    flankVersion = "20.05.2"
     serviceAccountCredentials = project.layout.projectDirectory.file("flank-gradle-5cf02dc90531.json")
-    // Project Id is not needed if serviceAccountCredentials are set.
-//    projectId("flank-gradle")
     useOrchestrator = true
     environmentVariables = [
             "clearPackageData": "true"
@@ -42,33 +40,16 @@ fladle {
             ]
             flakyTestAttempts = 3
         }
-        additionalTests {
-            useOrchestrator = false
-            testTargets = [
-                "class com.osacky.flank.gradle.sample.ExampleInstrumentedTest#runAndFail"
-            ]
-            flakyTestAttempts = 3
-            additionalTestApks.value(project.provider { [
-                "app: ../main/app/build/output/apk/debug/app.apk",
-                "test: ../main/app/build/output/apk/androidTest/debug/app-test.apk",
-                "app: ../sample/app/build/output/apk/debug/sample-app.apk",
-                "test: ../sample/app/build/output/apk/androidTest/debug/sample-app-test.apk",
-                "test: ../feature/room/build/output/apk/androidTest/debug/feature-room-test.apk",
-                "test: ../library/databases/build/output/apk/androidTest/debug/sample-databases-test.apk"
-            ]})
-        }
     }
-    flakyTestAttempts 1
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation('androidx.navigation:navigation-fragment-ktx:2.2.2')
+    implementation("androidx.navigation:navigation-fragment-ktx:2.2.2")
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     testImplementation 'junit:junit:4.13'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test:rules:1.2.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }
 

--- a/buildSrc/src/test/resources/android-project/src/androidTest/java/com/osacky/flank/gradle/sample/ExampleInstrumentedTest.java
+++ b/buildSrc/src/test/resources/android-project/src/androidTest/java/com/osacky/flank/gradle/sample/ExampleInstrumentedTest.java
@@ -1,0 +1,33 @@
+package com.osacky.flank.gradle.sample;
+
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.action.ViewActions.typeText;
+import java.lang.RuntimeException;
+
+@RunWith(AndroidJUnit4.class)
+public class ExampleInstrumentedTest {
+
+  @Rule
+  private final ActivityTestRule testRule = new ActivityTestRule(MainActivity.class);
+
+  @Test
+  public void seeView() {
+    onView(withId(R.id.text_view_hello)).check(matches(isDisplayed()));
+  }
+
+  @Test
+  public void runAndFail() {
+    throw new RuntimeException("Test failed");
+  }
+}

--- a/buildSrc/src/test/resources/android-project/src/main/AndroidManifest.xml
+++ b/buildSrc/src/test/resources/android-project/src/main/AndroidManifest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="com.osacky.flank.gradle.sample"
+          xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application
+        android:label="@string/app_name"
+    >
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/buildSrc/src/test/resources/android-project/src/main/java/com/osacky/flank/gradle/sample/MainActivity.java
+++ b/buildSrc/src/test/resources/android-project/src/main/java/com/osacky/flank/gradle/sample/MainActivity.java
@@ -1,0 +1,13 @@
+package com.osacky.flank.gradle.sample;
+
+import androidx.appcompat.app.AppCompatActivity;
+import android.os.Bundle;
+
+public class MainActivity extends AppCompatActivity {
+
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
+  }
+}

--- a/buildSrc/src/test/resources/android-project/src/main/res/layout/activity_main.xml
+++ b/buildSrc/src/test/resources/android-project/src/main/res/layout/activity_main.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".MainActivity">
+
+    <TextView
+        android:id="@+id/text_view_hello"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Hello World!"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/buildSrc/src/test/resources/android-project/src/main/res/values/strings.xml
+++ b/buildSrc/src/test/resources/android-project/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Flank Gradle Plugin Sample</string>
+</resources>

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,4 @@ org.gradle.jvmargs=-Xmx1536m
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
+android.enableJetifier=false

--- a/gradle/buildScanInit.gradle
+++ b/gradle/buildScanInit.gradle
@@ -1,0 +1,52 @@
+/**
+ * Adds a build scan to initialization script.
+ * Useful to debug errors in buildSrc.
+ *
+ * To use:
+ * ./gradlew -I gradle/buildScanInit.gradle <any gradle task>
+ */
+
+import com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin
+import com.gradle.scan.plugin.BuildScanPlugin
+import org.gradle.util.GradleVersion
+
+initscript {
+    def pluginVersion = "3.3.1"
+
+    repositories {
+        gradlePluginPortal()
+    }
+    dependencies {
+        classpath("com.gradle:gradle-enterprise-gradle-plugin:${pluginVersion}")
+    }
+}
+
+def isTopLevelBuild = gradle.getParent() == null
+
+if (isTopLevelBuild) {
+    def gradleVersion = GradleVersion.current().baseVersion
+    def atLeastGradle5 = gradleVersion >= GradleVersion.version("5.0")
+    def atLeastGradle6 = gradleVersion >= GradleVersion.version("6.0")
+
+    if (atLeastGradle6) {
+        settingsEvaluated {
+            if (!it.pluginManager.hasPlugin("com.gradle.enterprise")) {
+                it.pluginManager.apply(GradleEnterprisePlugin)
+            }
+            configureExtension(it.extensions["gradleEnterprise"])
+        }
+    } else if (atLeastGradle5) {
+        rootProject {
+            pluginManager.apply(BuildScanPlugin)
+            configureExtension(extensions["gradleEnterprise"])
+        }
+    }
+}
+
+void configureExtension(extension) {
+    extension.buildScan.with {
+        termsOfServiceUrl = "https://gradle.com/terms-of-service"
+        termsOfServiceAgree = "yes"
+        publishAlways()
+    }
+}

--- a/sample-android-library/build.gradle.kts
+++ b/sample-android-library/build.gradle.kts
@@ -18,10 +18,10 @@ android {
 dependencies {
   implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7")
   implementation("androidx.appcompat:appcompat:1.1.0")
-  implementation("android.arch.navigation:navigation-fragment-ktx:1.0.0")
+  implementation("androidx.navigation:navigation-fragment-ktx:2.2.2")
   implementation("androidx.constraintlayout:constraintlayout:1.1.3")
   testImplementation("junit:junit:4.13")
-  androidTestImplementation("androidx.test:runner:1.2.0")
+  androidTestImplementation("androidx.test.ext:junit:1.1.1")
   androidTestImplementation("androidx.test:rules:1.2.0")
   androidTestImplementation("androidx.test.espresso:espresso-core:3.2.0")
 }

--- a/sample-android-library/src/androidTest/java/com/osacky/flank/gradle/sample/ExampleInstrumentedTest.kt
+++ b/sample-android-library/src/androidTest/java/com/osacky/flank/gradle/sample/ExampleInstrumentedTest.kt
@@ -1,7 +1,7 @@
 package com.osacky.flank.gradle.sample
 
 
-import androidx.test.runner.AndroidJUnit4
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Test
 import org.junit.runner.RunWith
 

--- a/sample-flavors-kotlin/build.gradle.kts
+++ b/sample-flavors-kotlin/build.gradle.kts
@@ -75,11 +75,11 @@ fladle {
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7")
     implementation("androidx.appcompat:appcompat:1.1.0")
-    implementation("android.arch.navigation:navigation-fragment-ktx:1.0.0")
+    implementation("androidx.navigation:navigation-fragment-ktx:2.2.2")
     implementation("androidx.constraintlayout:constraintlayout:1.1.3")
     testImplementation("junit:junit:4.13")
-    androidTestImplementation("androidx.test:runner:1.2.0")
     androidTestImplementation("androidx.test:rules:1.2.0")
+    androidTestImplementation("androidx.test.ext:junit:1.1.1")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.2.0")
 }
 

--- a/sample-flavors-kotlin/src/androidTest/java/com/osacky/flank/gradle/sample/ExampleInstrumentedTest.kt
+++ b/sample-flavors-kotlin/src/androidTest/java/com/osacky/flank/gradle/sample/ExampleInstrumentedTest.kt
@@ -6,7 +6,7 @@ import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.rule.ActivityTestRule
-import androidx.test.runner.AndroidJUnit4
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.osacky.flank.gradle.sample.kotlin.R
 import org.junit.Rule
 import org.junit.Test

--- a/sample-flavors-kotlin/src/main/AndroidManifest.xml
+++ b/sample-flavors-kotlin/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="com.osacky.flank.gradle.sample.kotlin"
-          xmlns:android="http://schemas.android.com/apk/res/android">
+          xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
 
     <application
         android:allowBackup="true"
@@ -8,7 +8,10 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        tools:replace="android:appComponentFactory"
+        android:appComponentFactory="androidx.core.app.CoreComponentFactory"
+    >
         <activity android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
@@ -16,6 +19,7 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+
     </application>
 
 </manifest>

--- a/sample-kotlin/build.gradle.kts
+++ b/sample-kotlin/build.gradle.kts
@@ -59,10 +59,10 @@ fladle {
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7")
     implementation("androidx.appcompat:appcompat:1.1.0")
-    implementation("android.arch.navigation:navigation-fragment-ktx:1.0.0")
+    implementation("androidx.navigation:navigation-fragment-ktx:2.2.2")
     implementation("androidx.constraintlayout:constraintlayout:1.1.3")
     testImplementation("junit:junit:4.13")
-    androidTestImplementation("androidx.test:runner:1.2.0")
+    androidTestImplementation("androidx.test.ext:junit:1.1.1")
     androidTestImplementation("androidx.test:rules:1.2.0")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.2.0")
 }

--- a/sample-kotlin/src/androidTest/java/com/osacky/flank/gradle/sample/ExampleInstrumentedTest.kt
+++ b/sample-kotlin/src/androidTest/java/com/osacky/flank/gradle/sample/ExampleInstrumentedTest.kt
@@ -6,7 +6,7 @@ import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.rule.ActivityTestRule
-import androidx.test.runner.AndroidJUnit4
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.osacky.flank.gradle.sample.kotlin.R
 import org.junit.Rule
 import org.junit.Test

--- a/sample-kotlin/src/main/AndroidManifest.xml
+++ b/sample-kotlin/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="com.osacky.flank.gradle.sample.kotlin"
-          xmlns:android="http://schemas.android.com/apk/res/android">
+          xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
 
     <application
         android:allowBackup="true"
@@ -8,7 +8,10 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        tools:replace="android:appComponentFactory"
+        android:appComponentFactory="androidx.core.app.CoreComponentFactory"
+    >
         <activity android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>

--- a/sample/src/androidTest/java/com/osacky/flank/gradle/sample/ExampleInstrumentedTest.kt
+++ b/sample/src/androidTest/java/com/osacky/flank/gradle/sample/ExampleInstrumentedTest.kt
@@ -5,14 +5,12 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import androidx.test.rule.ActivityTestRule
-import androidx.test.runner.AndroidJUnit4
+import androidx.test.ext.junit.runners.AndroidJUnit4
 
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.matcher.ViewMatchers.withId
-import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.action.ViewActions.typeText
 import java.lang.RuntimeException
 
 @RunWith(AndroidJUnit4::class)


### PR DESCRIPTION
If roboscript is set in the fladle exention, we shouldn't try to also automatically configure
the instrumentationApk as this will lead to a confusing failure.

This also adds an integration test (finally) for the fladle plugin in an android project.
