### PR TITLE
Declare YamlConfigWriterTask output so it can be used from other tasks.

### DIFF
--- a/buildSrc/src/main/java/com/osacky/flank/gradle/YamlConfigWriterTask.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/YamlConfigWriterTask.kt
@@ -3,12 +3,19 @@ package com.osacky.flank.gradle
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
+import java.io.File
 import javax.inject.Inject
 
-open class YamlConfigWriterTask @Inject constructor(private val config: FladleConfig, private val extension: FlankGradleExtension, private val projectLayout: ProjectLayout) : DefaultTask() {
+open class YamlConfigWriterTask @Inject constructor(private val config: FladleConfig, private val extension: FlankGradleExtension, projectLayout: ProjectLayout) : DefaultTask() {
 
   private val yamlWriter = YamlWriter()
+
+  private val fladleDir = projectLayout.fladleDir.get().asFile
+
+  @OutputFile
+  val fladleConfigFile: File = fladleDir.resolve("flank.yml")
 
   @Internal
   override fun getDescription(): String {
@@ -22,10 +29,7 @@ open class YamlConfigWriterTask @Inject constructor(private val config: FladleCo
 
   @TaskAction
   fun writeFile() {
-    val fladleDir = projectLayout.fladleDir.get().asFile
-    if (!fladleDir.exists()) {
-      fladleDir.mkdirs()
-    }
-    fladleDir.resolve("flank.yml").writeText(yamlWriter.createConfigProps(config, extension))
+    fladleDir.mkdirs()
+    fladleConfigFile.writeText(yamlWriter.createConfigProps(config, extension))
   }
 }


### PR DESCRIPTION
I wanted to declare the inputs to (so it would be able to check if it's up-to-date) but:
`Caused by: org.gradle.internal.snapshot.ValueSnapshottingException: Could not serialize value of type FlankGradleExtension`

In any case this is useful so the yaml can be used as an input for FlankExecutionTask (one of many)