### PR TITLE
Increase Gradle min version to 6.0

### DIFF
--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FladlePluginDelegate.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FladlePluginDelegate.kt
@@ -35,7 +35,7 @@ class FladlePluginDelegate {
   }
 
   private fun checkMinimumGradleVersion() {
-    // Gradle 4.9 is required because we use the lazy task configuration API.
+    // Gradle 6.0 is required because we use ExecOperations.
     if (GRADLE_MIN_VERSION > GradleVersion.current()) {
       throw GradleException("Fladle requires at minimum version $GRADLE_MIN_VERSION. Detected version ${GradleVersion.current()}.")
     }
@@ -195,7 +195,7 @@ class FladlePluginDelegate {
     get() = configurations.getByName(FLADLE_CONFIG)
 
   companion object {
-    val GRADLE_MIN_VERSION: GradleVersion = GradleVersion.version("5.5")
+    val GRADLE_MIN_VERSION: GradleVersion = GradleVersion.version("6.0")
     const val TASK_GROUP = "fladle"
     const val FLADLE_CONFIG = "fladle"
     fun Project.log(message: String) {

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FlankGradlePluginIntegrationTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FlankGradlePluginIntegrationTest.kt
@@ -12,8 +12,8 @@ class FlankGradlePluginIntegrationTest {
   @get:Rule
   var testProjectRoot = TemporaryFolder()
 
-  val minSupportGradleVersion = "5.5"
-  val oldVersion = "5.3.1"
+  val minSupportGradleVersion = "6.0"
+  val oldVersion = "5.5"
 
   fun writeBuildGradle(build: String) {
     testProjectRoot.writeBuildDotGradle(build)
@@ -32,7 +32,7 @@ class FlankGradlePluginIntegrationTest {
       .withPluginClasspath()
       .withGradleVersion(oldVersion)
       .buildAndFail()
-    assertThat(result.output).contains("Fladle requires at minimum version Gradle 5.5. Detected version Gradle 5.3.1")
+    assertThat(result.output).contains("Fladle requires at minimum version Gradle 6.0. Detected version Gradle 5.5")
   }
 
   @Test


### PR DESCRIPTION
Thats required to make FlankExecutionTask a custom task (not extending JavaExec) so we can declare inputs and don't need to set all the properties in the init block.