### PR TITLE
Create file lazily.

### DIFF
--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FladlePluginDelegate.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FladlePluginDelegate.kt
@@ -57,25 +57,21 @@ class FladlePluginDelegate {
   }
 
   private fun TaskContainer.createTasksForConfig(base: FlankGradleExtension, config: FladleConfig, project: Project, name: String) {
-    val writeConfigProps = register("writeConfigProps$name", YamlConfigWriterTask::class.java, base)
-    writeConfigProps.configure {
-      fladleConfig = config
-      flankConfig.set(project.layout.buildDirectory.dir("fladle/${name.toLowerCase()}").map { it.file("flank.yml") })
-    }
+    val writeConfigProps = register("writeConfigProps$name", YamlConfigWriterTask::class.java, base, config, name)
 
     register("printYml$name") {
       description = "Print the flank.yml file to the console."
       group = TASK_GROUP
       dependsOn(writeConfigProps)
       doLast {
-        println(writeConfigProps.get().flankConfig.get().asFile.readText())
+        println(writeConfigProps.get().fladleConfigFile.get().asFile.readText())
       }
     }
 
     register("flankDoctor$name", FlankJavaExec::class.java) {
       description = "Finds problems with the current configuration."
       classpath = project.fladleConfig
-      args = listOf("firebase", "test", "android", "doctor", "-c", writeConfigProps.get().flankConfig.get().asFile.absolutePath)
+      args = listOf("firebase", "test", "android", "doctor", "-c", writeConfigProps.get().fladleConfigFile.get().asFile.absolutePath)
       dependsOn(writeConfigProps)
     }
 
@@ -84,9 +80,9 @@ class FladlePluginDelegate {
       description = "Runs instrumentation tests using flank on firebase test lab."
       classpath = project.fladleConfig
       args = if (project.hasProperty("dumpShards")) {
-        listOf("firebase", "test", "android", "run", "-c", writeConfigProps.get().flankConfig.get().asFile.absolutePath, "--dump-shards")
+        listOf("firebase", "test", "android", "run", "-c", writeConfigProps.get().fladleConfigFile.get().asFile.absolutePath, "--dump-shards")
       } else {
-        listOf("firebase", "test", "android", "run", "-c", writeConfigProps.get().flankConfig.get().asFile.absolutePath)
+        listOf("firebase", "test", "android", "run", "-c", writeConfigProps.get().fladleConfigFile.get().asFile.absolutePath)
       }
       if (config.serviceAccountCredentials.isPresent) {
         environment(mapOf("GOOGLE_APPLICATION_CREDENTIALS" to config.serviceAccountCredentials.get()))

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
@@ -6,12 +6,17 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
 import org.gradle.kotlin.dsl.listProperty
 import org.gradle.kotlin.dsl.property
 import javax.inject.Inject
 
 open class FlankGradleExtension @Inject constructor(objects: ObjectFactory) : FladleConfig {
+  @get:Input
   val flankCoordinates: Property<String> = objects.property(String::class.java).convention("com.github.flank:flank")
+  @get:Input
   val flankVersion: Property<String> = objects.property(String::class.java).convention("20.08.3")
   // Project id is automatically discovered by default. Use this to override the project id.
   override var projectId: String? = null
@@ -35,12 +40,18 @@ open class FlankGradleExtension @Inject constructor(objects: ObjectFactory) : Fl
   override var flakyTestAttempts = 0
 
   // Variant to use for configuring output APK.
-  var variant: Property<String> = objects.property()
+  @get:Input
+  @get:Optional
+  val variant: Property<String> = objects.property()
 
   /**
    * debugApk and instrumentationApk are [Property<String>] and not [RegularFileProperty] because we support wildcard characters.
    */
+  @get:Input
+  @get:Optional
   val debugApk: Property<String> = objects.property()
+  @get:Input
+  @get:Optional
   val instrumentationApk: Property<String> = objects.property()
 
   override var directoriesToPull: List<String> = emptyList()
@@ -59,11 +70,11 @@ open class FlankGradleExtension @Inject constructor(objects: ObjectFactory) : Fl
 
   override var resultsDir: String? = null
 
-  override var additionalTestApks: ListProperty<String> = objects.listProperty()
+  override val additionalTestApks: ListProperty<String> = objects.listProperty()
 
-  override var runTimeout: Property<String> = objects.property()
+  override val runTimeout: Property<String> = objects.property()
 
-  override var ignoreFailedTests: Property<Boolean> = objects.property()
+  override val ignoreFailedTests: Property<Boolean> = objects.property()
 
   override var disableSharding: Boolean = false
 
@@ -71,7 +82,7 @@ open class FlankGradleExtension @Inject constructor(objects: ObjectFactory) : Fl
 
   override var testRunnerClass: String? = null
 
-  override var localResultsDir: Property<String> = objects.property()
+  override val localResultsDir: Property<String> = objects.property()
 
   override var numUniformShards: Int? = null
 
@@ -89,8 +100,9 @@ open class FlankGradleExtension @Inject constructor(objects: ObjectFactory) : Fl
 
   override var testTimeout: String = "15m"
 
-  override var outputStyle: Property<String> = objects.property<String>().convention("single")
+  override val outputStyle: Property<String> = objects.property<String>().convention("single")
 
+  @Internal
   val configs: NamedDomainObjectContainer<FladleConfigImpl> = objects.domainObjectContainer(FladleConfigImpl::class.java) {
     FladleConfigImpl(
       name = it,

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/YamlConfigWriterTask.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/YamlConfigWriterTask.kt
@@ -9,6 +9,7 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
+import java.util.Locale
 import javax.inject.Inject
 
 open class YamlConfigWriterTask @Inject constructor(
@@ -24,7 +25,7 @@ open class YamlConfigWriterTask @Inject constructor(
     if (configName == "") {
       it
     } else {
-      it.dir(configName)
+      it.dir(configName.toLowerCase(Locale.ROOT))
     }
   }
 

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/YamlConfigWriterTask.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/YamlConfigWriterTask.kt
@@ -3,24 +3,33 @@ package com.osacky.flank.gradle
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFile
-import org.gradle.api.model.ObjectFactory
-import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import javax.inject.Inject
 
-open class YamlConfigWriterTask @Inject constructor(private val extension: FlankGradleExtension, projectLayout: ProjectLayout, objectFactory: ObjectFactory) : DefaultTask() {
+open class YamlConfigWriterTask @Inject constructor(
+  private val base: FlankGradleExtension,
+  @get:Nested val config: FladleConfig,
+  @get:Input val configName: String,
+  projectLayout: ProjectLayout
+) : DefaultTask() {
 
   private val yamlWriter = YamlWriter()
 
-  @get:Nested
-  var fladleConfig: FladleConfig? = null
+  private val fladleDir = projectLayout.fladleDir.map {
+    if (configName == "") {
+      it
+    } else {
+      it.dir(configName)
+    }
+  }
 
-  @get:OutputFile
-  val flankConfig: Property<RegularFile> =
-    objectFactory.fileProperty().convention(projectLayout.fladleDir.map { it.file("flank.yml") })
+  @OutputFile
+  val fladleConfigFile: Provider<RegularFile> = fladleDir.map { it.file("flank.yml") }
 
   @Internal
   override fun getDescription(): String {
@@ -34,7 +43,7 @@ open class YamlConfigWriterTask @Inject constructor(private val extension: Flank
 
   @TaskAction
   fun writeFile() {
-    val fladleConfig = checkNotNull(fladleConfig)
-    flankConfig.get().asFile.writeText(yamlWriter.createConfigProps(fladleConfig, extension))
+    fladleDir.get().asFile.mkdirs()
+    fladleConfigFile.get().asFile.writeText(yamlWriter.createConfigProps(config, base))
   }
 }

--- a/buildSrc/src/test/java/com/osacky/flank/gradle/MultipleConfigsTest.kt
+++ b/buildSrc/src/test/java/com/osacky/flank/gradle/MultipleConfigsTest.kt
@@ -35,11 +35,14 @@ class MultipleConfigsTest {
     )
     testProjectRoot.newFile("flank-gradle-service.json").writeText("{}")
 
-    GradleRunner.create()
+    val result = GradleRunner.create()
       .withPluginClasspath()
       .withArguments("writeConfigPropsOrange", "--stacktrace")
+      .forwardOutput()
       .withProjectDir(testProjectRoot.root)
       .build()
+
+    assertThat(result.output).contains("SUCCESS")
 
     val writtenYmlFile = testProjectRoot.root.resolve("build/fladle/orange/flank.yml")
     assertThat(writtenYmlFile.readText()).contains(

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionSha256Sum=371cb9fbebbe9880d147f59bab36d61eee122854ef8c9ee1ecf12b82368bcf10
 distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This avoids creating the file object until as late as possible. This is needed in case the projectlayout changes in the configuration phase.

This also fixes build deprecations added in previous pull requests.