### PR TITLE
Improve error messaging for setting roboScript and instrumentationApk

### DIFF
--- a/buildSrc/src/main/java/com/osacky/flank/gradle/YamlWriter.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/YamlWriter.kt
@@ -13,10 +13,15 @@ internal class YamlWriter {
     }
     check(base.debugApk.isPresent) { "debugApk must be specified" }
     check(base.instrumentationApk.isPresent xor !base.roboScript.orNull.isNullOrBlank()) {
+      val prefix = if (base.instrumentationApk.isPresent && !base.roboScript.orNull.isNullOrBlank()) {
+        "Both instrumentationApk file and roboScript file were specified, but only one is expected."
+      } else {
+        "Must specify either a instrumentationApk file or a roboScript file."
+      }
       """
-     Either instrumentationApk file or roboScript file must be specified but not both.
-     instrumentationApk=${base.instrumentationApk.orNull}
-     roboScript=${base.roboScript.orNull}
+      $prefix
+      instrumentationApk=${base.instrumentationApk.orNull}
+      roboScript=${base.roboScript.orNull}
       """.trimIndent()
     }
 

--- a/buildSrc/src/test/java/com/osacky/flank/gradle/YamlWriterTest.kt
+++ b/buildSrc/src/test/java/com/osacky/flank/gradle/YamlWriterTest.kt
@@ -201,7 +201,7 @@ class YamlWriterTest {
     } catch (expected: IllegalStateException) {
       assertThat(expected).hasMessageThat().isEqualTo(
         """
-        Either instrumentationApk file or roboScript file must be specified but not both.
+        Must specify either a instrumentationApk file or a roboScript file.
         instrumentationApk=null
         roboScript=null
         """.trimIndent()
@@ -223,7 +223,7 @@ class YamlWriterTest {
     } catch (expected: IllegalStateException) {
       assertThat(expected).hasMessageThat().isEqualTo(
         """
-        Either instrumentationApk file or roboScript file must be specified but not both.
+        Both instrumentationApk file and roboScript file were specified, but only one is expected.
         instrumentationApk=build/test/*.apk
         roboScript=foo
         """.trimIndent()

--- a/buildSrc/src/test/java/com/osacky/flank/gradle/integration/FlankGradlePluginIntegrationTest.kt
+++ b/buildSrc/src/test/java/com/osacky/flank/gradle/integration/FlankGradlePluginIntegrationTest.kt
@@ -146,7 +146,7 @@ class FlankGradlePluginIntegrationTest {
       .withArguments("runFlank")
       .buildAndFail()
 
-    assertThat(result.output).contains("Either instrumentationApk file or roboScript file must be specified but not both.")
+    assertThat(result.output).contains("Must specify either a instrumentationApk file or a roboScript file.")
   }
 
   @Test
@@ -171,6 +171,6 @@ class FlankGradlePluginIntegrationTest {
       .withArguments("printYml")
       .buildAndFail()
 
-    assertThat(result.output).contains("Either instrumentationApk file or roboScript file must be specified but not both.")
+    assertThat(result.output).contains("Both instrumentationApk file and roboScript file were specified, but only one is expected.")
   }
 }


### PR DESCRIPTION
Creates a unique error message if:
- the user specifies neither a roboScript or a instrumentationApk
- the user specifies both a roboScript and a instrumentationApk 

This should help with https://github.com/runningcode/fladle/issues/131

Let me know your thoughts or if there are any other improvements. Thanks! 