### PR TITLE
Update fladle with newest flank options

### DIFF
--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FladleConfig.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FladleConfig.kt
@@ -273,4 +273,44 @@ interface FladleConfig {
   @SinceFlank("20.06.0")
   @get:Input
   val fullJunitResult: Property<Boolean>
+
+  /**
+   * A list of up to 100 additional APKs to install, in addition to those being directly tested.
+   * The path may be in the local filesystem or in Google Cloud Storage using gs:// notation.
+   */
+  @get:Input
+  @get:Optional
+  val additionalApks: ListProperty<String>
+
+  /**
+   * Enable using average time from previous tests duration when using SmartShard and tests did not run before.
+   * (default: false)
+   */
+  @get:Input
+  @get:Optional
+  val useAverageTestTimeForNewTests: Property<Boolean>
+
+  /**
+   * Set default test time expressed in seconds, used for calculating shards.
+   * (default: 120.0s)
+   */
+  @get:Input
+  @get:Optional
+  val defaultTestTime: Property<Double>
+
+  /**
+   * Set default parameterized class test time expressed in seconds, used for calculating shards.
+   * (default: 2x [defaultTestTime] => 240s)
+   */
+  @get:Input
+  @get:Optional
+  val defaultClassTestTime: Property<Double>
+
+  /**
+   * Disable flank results upload on gcloud storage.
+   * (default: false)
+   */
+  @get:Input
+  @get:Optional
+  val disableResultsUpload: Property<Boolean>
 }

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FladleConfig.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FladleConfig.kt
@@ -59,7 +59,7 @@ interface FladleConfig {
   @get:Optional
   val shardTime: Property<Int>
 
-  @SinceFlank("8.0.0")
+  @get:SinceFlank("8.0.0")
   @get:Input
   @get:Optional
   val repeatTests: Property<Int>
@@ -96,7 +96,7 @@ interface FladleConfig {
   @get:Optional
   val resultsBucket: Property<String>
 
-  @get:SinceFlank("8.1.0")
+  @get:SinceFlank("8.1.0", hasDefaultValue = true)
   @get:Input
   val keepFilePath: Property<Boolean>
 
@@ -108,7 +108,7 @@ interface FladleConfig {
   @get:Optional
   val resultsDir: Property<String>
 
-  @SinceFlank("6.1.0")
+  @get:SinceFlank("6.1.0")
   @get:Input
   val additionalTestApks: ListProperty<String>
 
@@ -125,7 +125,7 @@ interface FladleConfig {
    * Useful for Fladle and other gradle plugins that don't expect the process to have a non-zero exit code.
    * The JUnit XML is used to determine failure. (default: false)
    */
-  @get:SinceFlank("20.05.0")
+  @get:SinceFlank("20.05.0", hasDefaultValue = true)
   @get:Input
   @get:Optional
   val ignoreFailedTests: Property<Boolean>
@@ -254,7 +254,7 @@ interface FladleConfig {
    * 'multi' is used as the default. The output style 'multi' is not displayed correctly on consoles
    * which don't support ansi codes, to avoid corrupted output use single or verbose.
    */
-  @get:SinceFlank("20.06.0")
+  @get:SinceFlank("20.06.0", hasDefaultValue = true)
   @get:Input
   val outputStyle: Property<String>
 
@@ -263,14 +263,14 @@ interface FladleConfig {
    * New way uses google api instead of merging xml files, but can generate slightly different output format.
    * This flag allows fallback for legacy xml junit results parsing
    */
-  @get:SinceFlank("20.05.0")
+  @get:SinceFlank("20.05.0", hasDefaultValue = true)
   @get:Input
   val legacyJunitResult: Property<Boolean>
 
   /**
    * Enables creating an additional local junit result on local storage with failure nodes on passed flaky tests.
    */
-  @SinceFlank("20.06.0")
+  @get:SinceFlank("20.06.0", hasDefaultValue = true)
   @get:Input
   val fullJunitResult: Property<Boolean>
 
@@ -278,6 +278,7 @@ interface FladleConfig {
    * A list of up to 100 additional APKs to install, in addition to those being directly tested.
    * The path may be in the local filesystem or in Google Cloud Storage using gs:// notation.
    */
+  @get:SinceFlank("20.05.0")
   @get:Input
   @get:Optional
   val additionalApks: ListProperty<String>
@@ -286,6 +287,7 @@ interface FladleConfig {
    * Enable using average time from previous tests duration when using SmartShard and tests did not run before.
    * (default: false)
    */
+  @get:SinceFlank("20.08.4")
   @get:Input
   @get:Optional
   val useAverageTestTimeForNewTests: Property<Boolean>
@@ -294,6 +296,7 @@ interface FladleConfig {
    * Set default test time expressed in seconds, used for calculating shards.
    * (default: 120.0s)
    */
+  @get:SinceFlank("20.08.4")
   @get:Input
   @get:Optional
   val defaultTestTime: Property<Double>
@@ -302,6 +305,7 @@ interface FladleConfig {
    * Set default parameterized class test time expressed in seconds, used for calculating shards.
    * (default: 2x [defaultTestTime] => 240s)
    */
+  @get:SinceFlank("20.08.4")
   @get:Input
   @get:Optional
   val defaultClassTestTime: Property<Double>
@@ -310,6 +314,7 @@ interface FladleConfig {
    * Disable flank results upload on gcloud storage.
    * (default: false)
    */
+  @get:SinceFlank("20.07.0")
   @get:Input
   @get:Optional
   val disableResultsUpload: Property<Boolean>

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FladleConfigImpl.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FladleConfigImpl.kt
@@ -47,7 +47,12 @@ data class FladleConfigImpl(
   override val testTimeout: Property<String>,
   override val outputStyle: Property<String>,
   override val legacyJunitResult: Property<Boolean>,
-  override val fullJunitResult: Property<Boolean>
+  override val fullJunitResult: Property<Boolean>,
+  override val additionalApks: ListProperty<String>,
+  override val defaultTestTime: Property<Double>,
+  override val useAverageTestTimeForNewTests: Property<Boolean>,
+  override val defaultClassTestTime: Property<Double>,
+  override val disableResultsUpload: Property<Boolean>
 ) : FladleConfig {
   /**
    * Prepare config to run sanity robo.

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
@@ -108,6 +108,15 @@ open class FlankGradleExtension @Inject constructor(objects: ObjectFactory) : Fl
 
   override val fullJunitResult: Property<Boolean> = objects.property<Boolean>().convention(false)
 
+  override val additionalApks: ListProperty<String> = objects.listProperty()
+
+  override val defaultTestTime: Property<Double> = objects.property()
+
+  override val useAverageTestTimeForNewTests: Property<Boolean> = objects.property()
+
+  override val defaultClassTestTime: Property<Double> = objects.property()
+
+  override val disableResultsUpload: Property<Boolean> = objects.property()
   @Internal
   val configs: NamedDomainObjectContainer<FladleConfigImpl> = objects.domainObjectContainer(FladleConfigImpl::class.java) {
     FladleConfigImpl(
@@ -152,7 +161,12 @@ open class FlankGradleExtension @Inject constructor(objects: ObjectFactory) : Fl
       testTimeout = objects.property<String>().convention(testTimeout),
       outputStyle = objects.property<String>().convention(outputStyle),
       legacyJunitResult = objects.property<Boolean>().convention(legacyJunitResult),
-      fullJunitResult = objects.property<Boolean>().convention(fullJunitResult)
+      fullJunitResult = objects.property<Boolean>().convention(fullJunitResult),
+      additionalApks = objects.listProperty<String>().convention(additionalApks),
+      useAverageTestTimeForNewTests = objects.property<Boolean>().convention(useAverageTestTimeForNewTests),
+      defaultTestTime = objects.property<Double>().convention(defaultTestTime),
+      defaultClassTestTime = objects.property<Double>().convention(defaultClassTestTime),
+      disableResultsUpload = objects.property<Boolean>().convention(disableResultsUpload)
     )
   }
 

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/YamlWriter.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/YamlWriter.kt
@@ -63,6 +63,10 @@ internal class YamlWriter {
     appendProperty(config.legacyJunitResult, name = "legacy-junit-result")
     appendProperty(config.fullJunitResult, name = "full-junit-result")
     appendProperty(config.outputStyle, name = "output-style")
+    appendProperty(config.defaultTestTime, name = "default-test-time")
+    appendProperty(config.defaultClassTestTime, name = "default-class-test-time")
+    appendProperty(config.useAverageTestTimeForNewTests, name = "use-average-test-time-for-new-tests")
+    appendProperty(config.disableResultsUpload, name = "disable-results-upload")
   }
 
   internal fun writeAdditionalProperties(config: FladleConfig): String = buildString {
@@ -92,6 +96,7 @@ internal class YamlWriter {
         appendln("    ${it[0]}:${it[1]}: $value")
       }
     }
+    appendListProperty(config.additionalApks, name = "additional-apks") { appendln("    - $it") }
   }
 
   private fun <T> StringBuilder.appendProperty(prop: Property<T>, name: String) {

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/validation/SinceFlank.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/validation/SinceFlank.kt
@@ -1,3 +1,3 @@
 package com.osacky.flank.gradle.validation
 
-annotation class SinceFlank(val version: String)
+annotation class SinceFlank(val version: String, val hasDefaultValue: Boolean = false)

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/validation/ValidateOptions.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/validation/ValidateOptions.kt
@@ -28,6 +28,8 @@ private fun String.toVersion() = VersionNumber.parse(this)
 private val properties = FladleConfig::class.memberProperties
   .asSequence()
   .map { it to it.getter.annotations }
-  .filter { it.second.any { annotation -> annotation is SinceFlank } }
+  // we also need to exclude properties with default values to preserve backward compatibility
+  // to be fixed
+  .filter { it.second.any { annotation -> annotation is SinceFlank && !annotation.hasDefaultValue } }
   .map { it.first.name to it.second.filterIsInstance<SinceFlank>().first().version.toVersion() }
   .toMap()

--- a/buildSrc/src/test/java/com/osacky/flank/gradle/YamlWriterTest.kt
+++ b/buildSrc/src/test/java/com/osacky/flank/gradle/YamlWriterTest.kt
@@ -1118,6 +1118,61 @@ class YamlWriterTest {
     )
   }
 
+  @Test
+  fun writeDefaultTestTime() {
+    val properties = emptyExtension {
+      defaultTestTime.set(240.5)
+    }.toFlankProperties()
+
+    assertThat(properties).contains("default-test-time: 240.5")
+  }
+
+  @Test
+  fun writeDefaultClassTestTime() {
+    val properties = emptyExtension {
+      defaultClassTestTime.set(681.8)
+    }.toFlankProperties()
+
+    assertThat(properties).contains("default-class-test-time: 681.8")
+  }
+
+  @Test
+  fun writeUseAverageTestTimeForNewTests() {
+    val properties = emptyExtension {
+      useAverageTestTimeForNewTests.set(true)
+    }.toFlankProperties()
+
+    assertThat(properties).contains("use-average-test-time-for-new-tests: true")
+  }
+
+  @Test
+  fun writeAdditionalApks() {
+    val properties = emptyExtension {
+      additionalApks.set(
+        project.provider {
+          listOf("gs://path/to/app1.apk", "localPath/to/app2.apk")
+        }
+      )
+    }.toAdditionalProperties()
+
+    assertThat(properties).contains(
+      """
+      |  additional-apks:
+      |    - gs://path/to/app1.apk
+      |    - localPath/to/app2.apk
+      """.trimMargin()
+    )
+  }
+
+  @Test
+  fun writeDisableResultsUpload() {
+    val properties = emptyExtension {
+      disableResultsUpload.set(true)
+    }.toFlankProperties()
+
+    assertThat(properties).contains("disable-results-upload: true")
+  }
+
   private fun emptyExtension() = FlankGradleExtension(project.objects)
   private fun emptyExtension(block: FlankGradleExtension.() -> Unit) = emptyExtension().apply(block)
   private fun FlankGradleExtension.toFlankProperties() = yamlWriter.writeFlankProperties(this).trimIndent()

--- a/buildSrc/src/test/java/com/osacky/flank/gradle/validation/ValidateOptionsTest.kt
+++ b/buildSrc/src/test/java/com/osacky/flank/gradle/validation/ValidateOptionsTest.kt
@@ -27,10 +27,10 @@ class ValidateOptionsTest {
 
   @Test
   fun `should throw an error when unavailable option used`() {
-    config.outputStyle.set("single")
+    config.useAverageTestTimeForNewTests.set(true)
 
     assertThrows(IllegalStateException::class.java) { validateOptionsUsed(config, "20.05.0") }.run {
-      assertThat(message).containsMatch("Option outputStyle is available since flank 20.6.0, which is higher than used 20.5.0")
+      assertThat(message).containsMatch("Option useAverageTestTimeForNewTests is available since flank 20.8.4, which is higher than used 20.5.0")
     }
   }
 
@@ -55,7 +55,7 @@ class ValidateOptionsTest {
       |  flankVersion.set("20.05.0")
       |  configs {
       |    newNetwork {
-      |      outputStyle.set("verbose")
+      |      useAverageTestTimeForNewTests.set(true)
       |    }
       |    noSharding {
       |      disableSharding.set(true)
@@ -69,17 +69,17 @@ class ValidateOptionsTest {
 
     runner.withArguments("printYml").buildAndFail().run {
       assertThat(output).contains("FAILED")
-      assertThat(output).contains("Option outputStyle is available since flank 20.6.0, which is higher than used 20.5.0")
+      assertThat(output).contains("Option useAverageTestTimeForNewTests is available since flank 20.8.4, which is higher than used 20.5.0")
     }
 
     runner.withArguments("printYmlNewNetwork").buildAndFail().run {
       assertThat(output).contains("FAILED")
-      assertThat(output).contains("Option outputStyle is available since flank 20.6.0, which is higher than used 20.5.0")
+      assertThat(output).contains("Option useAverageTestTimeForNewTests is available since flank 20.8.4, which is higher than used 20.5.0")
     }
 
     runner.withArguments("printYmlNoSharding").buildAndFail().run {
       assertThat(output).contains("FAILED")
-      assertThat(output).contains("Option outputStyle is available since flank 20.6.0, which is higher than used 20.5.0")
+      assertThat(output).contains("Option useAverageTestTimeForNewTests is available since flank 20.8.4, which is higher than used 20.5.0")
     }
   }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,12 @@
 # Changelog
 
 ## Unreleased
+* Add support for newly added flank options [PR#186](https://github.com/runningcode/fladle/pull/186) Thanks [pawelpasterz](https://github.com/pawelpasterz): 
+    * `default-test-time`
+    * `default-class-test-time`
+    * `additional-apks`
+    * `use-average-test-time-for-new-tests`
+    * `disable-results-upload`
 
 ## 0.13.0
 * Add support for sanityRobo tests [Fixes #165](https://github.com/runningcode/fladle/issues/165) [PR](https://github.com/runningcode/fladle/pull/177) Thanks [pawelpasterz](https://github.com/pawelpasterz)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -122,6 +122,13 @@ fladle {
     outputStyle = 'multi'
     legacyJunitResult = false
     fullJunitResult = false
+    additional-apks:
+      - gs://path/to/app1.apk
+      - localPath/to/app2.apk
+    default-test-time: 5.3
+    default-class-test-time: 180.5
+    use-average-test-time-for-new-tests: true
+    disable-results-upload: true
 }
 ```
 
@@ -766,4 +773,71 @@ sanityRobo = true
 === "Kotlin"
 ``` kotlin
 sanityRobo.set(true)
+```
+
+### defaultTestTime
+Set default test time expressed in seconds, used for calculating shards. (default: 120.0s)
+
+=== "Groovy"
+``` groovy
+defaultTestTime = 1.2
+```
+=== "Kotlin"
+``` kotlin
+defaultTestTime.set(1.2)
+```
+
+### defaultClassTestTime
+Set default parameterized class test time expressed in seconds, used for calculating shards. (default: 2x [defaultTestTime](configuration.md#defaulttesttime) => 240s)
+
+=== "Groovy"
+``` groovy
+defaultClassTestTime = 245.5
+```
+=== "Kotlin"
+``` kotlin
+defaultClassTestTime.set(245,5)
+```
+
+### additionalApks
+A list of up to 100 additional APKs to install, in addition to those being directly tested. The path may be in the local filesystem or in Google Cloud Storage using gs:// notation.
+
+=== "Groovy"
+``` groovy
+additionalApks = [
+  "gs://path/to/app1.apk",
+  "localPath/to/app2.apk"
+]
+```
+=== "Kotlin"
+``` kotlin
+additionalApks.set(
+  project.provider {
+    listOf("gs://path/to/app1.apk", "localPath/to/app2.apk")
+  }
+)
+```
+
+### useAverageTestTimeForNewTests
+Enable using average time from previous tests duration when using SmartShard and tests did not run before. (default: false)
+
+=== "Groovy"
+``` groovy
+useAverageTestTimeForNewTests = true
+```
+=== "Kotlin"
+``` kotlin
+useAverageTestTimeForNewTests.set(true)
+```
+
+### disableResultsUpload
+Disable flank results upload on gcloud storage. (default: false)
+
+=== "Groovy"
+``` groovy
+disableResultsUpload = true
+```
+=== "Kotlin"
+``` kotlin
+disableResultsUpload.set(true)
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -123,7 +123,7 @@ fladle {
     legacyJunitResult = false
     fullJunitResult = false
     additionalApks = [
-      "gs://path/to/app1.apk"
+      "gs://path/to/app1.apk",
       "localPath/to/app2.apk"
     ]
     defaultTestTime = 5.3
@@ -768,77 +768,77 @@ Runs a sanityRobo test.
 `instrumentationApk`, `roboDirectives`, `roboScript` and `additionalTestApks` must be blank or empty.
 
 === "Groovy"
-``` groovy
-sanityRobo = true
-```
+    ``` groovy
+    sanityRobo = true
+    ```
 === "Kotlin"
-``` kotlin
-sanityRobo.set(true)
-```
+    ``` kotlin
+    sanityRobo.set(true)
+    ```
 
 ### defaultTestTime
 Set default test time expressed in seconds, used for calculating shards. (default: 120.0s)
 
 === "Groovy"
-``` groovy
-defaultTestTime = 1.2
-```
+    ``` groovy
+    defaultTestTime = 1.2
+    ```
 === "Kotlin"
-``` kotlin
-defaultTestTime.set(1.2)
-```
+    ``` kotlin
+    defaultTestTime.set(1.2)
+    ```
 
 ### defaultClassTestTime
 Set default parameterized class test time expressed in seconds, used for calculating shards. (default: 2x [defaultTestTime](configuration.md#defaulttesttime) => 240s)
 
 === "Groovy"
-``` groovy
-defaultClassTestTime = 245.5
-```
+    ``` groovy
+    defaultClassTestTime = 245.5
+    ```
 === "Kotlin"
-``` kotlin
-defaultClassTestTime.set(245,5)
-```
+    ``` kotlin
+    defaultClassTestTime.set(245,5)
+    ```
 
 ### additionalApks
 A list of up to 100 additional APKs to install, in addition to those being directly tested. The path may be in the local filesystem or in Google Cloud Storage using gs:// notation.
 
 === "Groovy"
-``` groovy
-additionalApks = [
-  "gs://path/to/app1.apk",
-  "localPath/to/app2.apk"
-]
-```
+    ``` groovy
+    additionalApks = [
+      "gs://path/to/app1.apk",
+      "localPath/to/app2.apk"
+    ]
+    ```
 === "Kotlin"
-``` kotlin
-additionalApks.set(
-  project.provider {
-    listOf("gs://path/to/app1.apk", "localPath/to/app2.apk")
-  }
-)
-```
+    ``` kotlin
+    additionalApks.set(
+      project.provider {
+         listOf("gs://path/to/app1.apk", "localPath/to/app2.apk")
+      }
+    )
+    ```
 
 ### useAverageTestTimeForNewTests
 Enable using average time from previous tests duration when using SmartShard and tests did not run before. (default: false)
 
 === "Groovy"
-``` groovy
-useAverageTestTimeForNewTests = true
-```
+    ``` groovy
+    useAverageTestTimeForNewTests = true
+    ```
 === "Kotlin"
-``` kotlin
-useAverageTestTimeForNewTests.set(true)
-```
+    ``` kotlin
+    useAverageTestTimeForNewTests.set(true)
+    ```
 
 ### disableResultsUpload
 Disable flank results upload on gcloud storage. (default: false)
 
 === "Groovy"
-``` groovy
-disableResultsUpload = true
-```
+    ``` groovy
+    disableResultsUpload = true
+    ```
 === "Kotlin"
-``` kotlin
-disableResultsUpload.set(true)
-```
+    ``` kotlin
+    disableResultsUpload.set(true)
+    ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -95,7 +95,7 @@ fladle {
     }
     resultsBucket("my-results-bucket-name")
     keepFilePath = true
-    runTimout = 45m
+    runTimout = "45m"
     ignoreFailedTests = false
     disableSharding = false
     smartFlankDisableUpload = false
@@ -122,13 +122,14 @@ fladle {
     outputStyle = 'multi'
     legacyJunitResult = false
     fullJunitResult = false
-    additional-apks:
-      - gs://path/to/app1.apk
-      - localPath/to/app2.apk
-    default-test-time: 5.3
-    default-class-test-time: 180.5
-    use-average-test-time-for-new-tests: true
-    disable-results-upload: true
+    additionalApks = [
+      "gs://path/to/app1.apk"
+      "localPath/to/app2.apk"
+    ]
+    defaultTestTime = 5.3
+    defaultClassTestTime = 180.5
+    useAverageTestTimeForNewTests = true
+    disableResultsUpload = true
 }
 ```
 


### PR DESCRIPTION
#### Flank has recently introduced few new configuration options:
1. `default-test-time`
2. `default-class-test-time`
3. `additional-apks`
4. `use-average-test-time-for-new-tests`
5. `disable-results-upload`