### PR TITLE
Remove fladle's default values [proposal]

### DIFF
--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FladleConfig.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FladleConfig.kt
@@ -32,16 +32,20 @@ interface FladleConfig {
   val sanityRobo: Property<Boolean>
 
   @get:Input
+  @get:Optional
   val useOrchestrator: Property<Boolean>
 
   @get:Input
+  @get:Optional
   val autoGoogleLogin: Property<Boolean>
 
   @get:Input
+  @get:Optional
   val devices: ListProperty<Map<String, String>>
 
   // https://cloud.google.com/sdk/gcloud/reference/firebase/test/android/run
   @get:Input
+  @get:Optional
   val testTargets: ListProperty<String>
 
   @get:Input
@@ -71,22 +75,28 @@ interface FladleConfig {
   val resultsHistoryName: Property<String>
 
   @get:Input
+  @get:Optional
   val directoriesToPull: ListProperty<String>
 
   @get:Input
+  @get:Optional
   val filesToDownload: ListProperty<String>
 
   @get:Input
+  @get:Optional
   val environmentVariables: MapProperty<String, String>
 
   @get:Input
+  @get:Optional
   val recordVideo: Property<Boolean>
 
   @get:Input
+  @get:Optional
   val performanceMetrics: Property<Boolean>
 
   // The number of times to retry failed tests. Default is 0. Max is 10.
   @get:Input
+  @get:Optional
   val flakyTestAttempts: Property<Int>
 
   @get:Input
@@ -94,6 +104,7 @@ interface FladleConfig {
   val resultsBucket: Property<String>
 
   @get:Input
+  @get:Optional
   val keepFilePath: Property<Boolean>
 
   /**
@@ -105,6 +116,7 @@ interface FladleConfig {
   val resultsDir: Property<String>
 
   @get:Input
+  @get:Optional
   val additionalTestApks: ListProperty<String>
 
   /**
@@ -127,12 +139,14 @@ interface FladleConfig {
    * Disables sharding. Useful for parameterized tests. (default: false)
    */
   @get:Input
+  @get:Optional
   val disableSharding: Property<Boolean>
 
   /**
    * Disables smart flank JUnit XML uploading. Useful for preventing timing data from being updated. (default: false)
    */
   @get:Input
+  @get:Optional
   val smartFlankDisableUpload: Property<Boolean>
 
   /**
@@ -172,6 +186,7 @@ interface FladleConfig {
    * these details can add additional context such as a link to the corresponding pull request.
    */
   @get:Input
+  @get:Optional
   val clientDetails: MapProperty<String, String>
 
   /**
@@ -179,6 +194,7 @@ interface FladleConfig {
    * useful if you need to grant permissions or login before other tests run
    */
   @get:Input
+  @get:Optional
   val testTargetsAlwaysRun: ListProperty<String>
 
   /**
@@ -187,6 +203,7 @@ interface FladleConfig {
    * Source file paths may be in the local filesystem or in Google Cloud Storage (gs://…).
    */
   @get:Input
+  @get:Optional
   val otherFiles: MapProperty<String, String>
 
   /**
@@ -217,6 +234,7 @@ interface FladleConfig {
    * Values are only permitted for text type elements, so no value should be specified for click and ignore type elements.
    */
   @get:Input
+  @get:Optional
   val roboDirectives: ListProperty<List<String>>
 
   /**
@@ -232,6 +250,7 @@ interface FladleConfig {
    * * 100  -> 100 seconds
    */
   @get:Input
+  @get:Optional
   val testTimeout: Property<String>
 
   /**
@@ -241,6 +260,7 @@ interface FladleConfig {
    * which don't support ansi codes, to avoid corrupted output use single or verbose.
    */
   @get:Input
+  @get:Optional
   val outputStyle: Property<String>
 
   /**
@@ -249,11 +269,13 @@ interface FladleConfig {
    * This flag allows fallback for legacy xml junit results parsing
    */
   @get:Input
+  @get:Optional
   val legacyJunitResult: Property<Boolean>
 
   /**
    * Enables creating an additional local junit result on local storage with failure nodes on passed flaky tests.
    */
   @get:Input
+  @get:Optional
   val fullJunitResult: Property<Boolean>
 }

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage")
+
 package com.osacky.flank.gradle
 
 import groovy.lang.Closure
@@ -26,9 +28,9 @@ open class FlankGradleExtension @Inject constructor(objects: ObjectFactory) : Fl
   // Project id is automatically discovered by default. Use this to override the project id.
   override val projectId: Property<String> = objects.property()
   override val serviceAccountCredentials: RegularFileProperty = objects.fileProperty()
-  override val useOrchestrator: Property<Boolean> = objects.property<Boolean>().convention(false)
-  override val autoGoogleLogin: Property<Boolean> = objects.property<Boolean>().convention(false)
-  override val devices: ListProperty<Map<String, String>> = objects.listProperty<Map<String, String>>().convention(listOf(mapOf("model" to "NexusLowRes", "version" to "28")))
+  override val useOrchestrator: Property<Boolean> = objects.property()
+  override val autoGoogleLogin: Property<Boolean> = objects.property()
+  override val devices: ListProperty<Map<String, String>> = objects.listProperty()
 
   // https://cloud.google.com/sdk/gcloud/reference/firebase/test/android/run
   override val testTargets: ListProperty<String> = objects.listProperty()
@@ -42,7 +44,7 @@ open class FlankGradleExtension @Inject constructor(objects: ObjectFactory) : Fl
 
   override val resultsHistoryName: Property<String> = objects.property()
 
-  override val flakyTestAttempts: Property<Int> = objects.property<Int>().convention(0)
+  override val flakyTestAttempts: Property<Int> = objects.property()
 
   // Variant to use for configuring output APK.
   @get:Input
@@ -62,13 +64,13 @@ open class FlankGradleExtension @Inject constructor(objects: ObjectFactory) : Fl
 
   override val environmentVariables: MapProperty<String, String> = objects.mapProperty()
 
-  override val recordVideo: Property<Boolean> = objects.property<Boolean>().convention(true)
+  override val recordVideo: Property<Boolean> = objects.property()
 
-  override val performanceMetrics: Property<Boolean> = objects.property<Boolean>().convention(true)
+  override val performanceMetrics: Property<Boolean> = objects.property()
 
   override val resultsBucket: Property<String> = objects.property()
 
-  override val keepFilePath: Property<Boolean> = objects.property<Boolean>().convention(false)
+  override val keepFilePath: Property<Boolean> = objects.property()
 
   override val resultsDir: Property<String> = objects.property()
 
@@ -76,11 +78,11 @@ open class FlankGradleExtension @Inject constructor(objects: ObjectFactory) : Fl
 
   override val runTimeout: Property<String> = objects.property()
 
-  override val ignoreFailedTests: Property<Boolean> = objects.property<Boolean>().convention(false)
+  override val ignoreFailedTests: Property<Boolean> = objects.property()
 
-  override val disableSharding: Property<Boolean> = objects.property<Boolean>().convention(false)
+  override val disableSharding: Property<Boolean> = objects.property()
 
-  override val smartFlankDisableUpload: Property<Boolean> = objects.property<Boolean>().convention(false)
+  override val smartFlankDisableUpload: Property<Boolean> = objects.property()
 
   override val testRunnerClass: Property<String> = objects.property()
 
@@ -100,13 +102,13 @@ open class FlankGradleExtension @Inject constructor(objects: ObjectFactory) : Fl
 
   override val roboDirectives: ListProperty<List<String>> = objects.listProperty()
 
-  override val testTimeout: Property<String> = objects.property<String>().convention("15m")
+  override val testTimeout: Property<String> = objects.property()
 
-  override val outputStyle: Property<String> = objects.property<String>().convention("single")
+  override val outputStyle: Property<String> = objects.property()
 
-  override val legacyJunitResult: Property<Boolean> = objects.property<Boolean>().convention(false)
+  override val legacyJunitResult: Property<Boolean> = objects.property()
 
-  override val fullJunitResult: Property<Boolean> = objects.property<Boolean>().convention(false)
+  override val fullJunitResult: Property<Boolean> = objects.property()
 
   @Internal
   val configs: NamedDomainObjectContainer<FladleConfigImpl> = objects.domainObjectContainer(FladleConfigImpl::class.java) {

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/YamlWriter.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/YamlWriter.kt
@@ -5,7 +5,7 @@ import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.internal.impldep.com.google.common.annotations.VisibleForTesting
 
-internal class YamlWriter {
+class YamlWriter {
 
   internal fun createConfigProps(config: FladleConfig, base: FlankGradleExtension): String {
     if (base.projectId.orNull == null) {

--- a/buildSrc/src/test/java/com/osacky/flank/gradle/MultipleConfigsTest.kt
+++ b/buildSrc/src/test/java/com/osacky/flank/gradle/MultipleConfigsTest.kt
@@ -52,24 +52,10 @@ class MultipleConfigsTest {
       |gcloud:
       |  app: foo.apk
       |  test: instrument.apk
-      |  device:
-      |  - model: NexusLowRes
-      |    version: 28
-      |
-      |  use-orchestrator: false
-      |  auto-google-login: false
-      |  record-video: true
-      |  performance-metrics: true
-      |  timeout: 15m
       |  test-targets:
       |  - override
-      |  num-flaky-test-attempts: 0
       |
       |flank:
-      |  keep-file-path: false
-      |  ignore-failed-tests: false
-      |  disable-sharding: false
-      |  smart-flank-disable-upload: false
       |  local-result-dir: overrideDir
     """.trimMargin()
     )
@@ -89,24 +75,10 @@ class MultipleConfigsTest {
       |gcloud:
       |  app: foo.apk
       |  test: instrument.apk
-      |  device:
-      |  - model: NexusLowRes
-      |    version: 28
-      |
-      |  use-orchestrator: false
-      |  auto-google-login: false
-      |  record-video: true
-      |  performance-metrics: true
-      |  timeout: 15m
       |  test-targets:
       |  - default
-      |  num-flaky-test-attempts: 0
       |
       |flank:
-      |  keep-file-path: false
-      |  ignore-failed-tests: false
-      |  disable-sharding: false
-      |  smart-flank-disable-upload: false
       |  local-result-dir: defaultDir
       """.trimMargin()
     )

--- a/buildSrc/src/test/java/com/osacky/flank/gradle/YamlWriterTest.kt
+++ b/buildSrc/src/test/java/com/osacky/flank/gradle/YamlWriterTest.kt
@@ -4,7 +4,6 @@ import com.google.common.truth.Truth.assertThat
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
@@ -152,26 +151,9 @@ class YamlWriterTest {
              gcloud:
                app: path
                test: instrument
-               device:
-               - model: NexusLowRes
-                 version: 28
-
-               use-orchestrator: false
-               auto-google-login: false
-               record-video: true
-               performance-metrics: true
-               timeout: 15m
-               num-flaky-test-attempts: 0
 
              flank:
                project: set
-               keep-file-path: false
-               ignore-failed-tests: false
-               disable-sharding: false
-               smart-flank-disable-upload: false
-               legacy-junit-result: false
-               full-junit-result: false
-               output-style: single
       """.trimIndent() + '\n' // Dunno why this needs to be here to make the tests pass.
     )
   }
@@ -243,26 +225,9 @@ class YamlWriterTest {
       """
     gcloud:
       app: path
-      device:
-      - model: NexusLowRes
-        version: 28
-
-      use-orchestrator: false
-      auto-google-login: false
-      record-video: true
-      performance-metrics: true
-      timeout: 15m
-      num-flaky-test-attempts: 0
       robo-script: foo
 
     flank:
-      keep-file-path: false
-      ignore-failed-tests: false
-      disable-sharding: false
-      smart-flank-disable-upload: false
-      legacy-junit-result: false
-      full-junit-result: false
-      output-style: single
       """.trimIndent() + '\n'
     )
   }
@@ -270,116 +235,52 @@ class YamlWriterTest {
   @Test
   fun writeNoTestShards() {
     val extension = emptyExtension {
-    }
+    }.toFlankProperties()
 
-    assertEquals(
-      "flank:\n" +
-        "  keep-file-path: false\n" +
-        "  ignore-failed-tests: false\n" +
-        "  disable-sharding: false\n" +
-        "  smart-flank-disable-upload: false\n" +
-        "  legacy-junit-result: false\n" +
-        "  full-junit-result: false\n" +
-        "  output-style: single\n",
-      yamlWriter.writeFlankProperties(extension)
-    )
+    assertThat(extension).doesNotContain("max-test-shards")
   }
 
   @Test
   fun writeProjectIdOption() {
     val extension = emptyExtension {
       projectId.set("foo")
-    }
+    }.toFlankProperties()
 
-    assertEquals(
-      "flank:\n" +
-        "  project: foo\n" +
-        "  keep-file-path: false\n" +
-        "  ignore-failed-tests: false\n" +
-        "  disable-sharding: false\n" +
-        "  smart-flank-disable-upload: false\n" +
-        "  legacy-junit-result: false\n" +
-        "  full-junit-result: false\n" +
-        "  output-style: single\n",
-      yamlWriter.writeFlankProperties(extension)
-    )
+    assertThat(extension).containsMatch("project: foo")
   }
 
   @Test
   fun writeTestShardOption() {
     val extension = emptyExtension {
       testShards.set(5)
-    }
+    }.toFlankProperties()
 
-    assertEquals(
-      "flank:\n" +
-        "  max-test-shards: 5\n" +
-        "  keep-file-path: false\n" +
-        "  ignore-failed-tests: false\n" +
-        "  disable-sharding: false\n" +
-        "  smart-flank-disable-upload: false\n" +
-        "  legacy-junit-result: false\n" +
-        "  full-junit-result: false\n" +
-        "  output-style: single\n",
-      yamlWriter.writeFlankProperties(extension)
-    )
+    assertThat(extension).containsMatch("max-test-shards: 5")
   }
 
   @Test
   fun writeShardTimeOption() {
     val extension = emptyExtension {
       shardTime.set(120)
-    }
+    }.toFlankProperties()
 
-    assertEquals(
-      "flank:\n" +
-        "  shard-time: 120\n" +
-        "  keep-file-path: false\n" +
-        "  ignore-failed-tests: false\n" +
-        "  disable-sharding: false\n" +
-        "  smart-flank-disable-upload: false\n" +
-        "  legacy-junit-result: false\n" +
-        "  full-junit-result: false\n" +
-        "  output-style: single\n",
-      yamlWriter.writeFlankProperties(extension)
-    )
+    assertThat(extension).containsMatch("shard-time: 120")
   }
 
   @Test
   fun writeNoTestRepeats() {
-    val extension = emptyExtension {}
+    val extension = emptyExtension {}.toFlankProperties()
 
-    assertEquals(
-      "flank:\n" +
-        "  keep-file-path: false\n" +
-        "  ignore-failed-tests: false\n" +
-        "  disable-sharding: false\n" +
-        "  smart-flank-disable-upload: false\n" +
-        "  legacy-junit-result: false\n" +
-        "  full-junit-result: false\n" +
-        "  output-style: single\n",
-      yamlWriter.writeFlankProperties(extension)
-    )
+    assertThat(extension).doesNotContain("num-test-runs")
   }
 
   @Test
   fun writeTestRepeats() {
     val extension = emptyExtension {
       repeatTests.set(5)
-    }
+    }.toFlankProperties()
 
-    assertEquals(
-      "flank:\n" +
-        "  num-test-runs: 5\n" +
-        "  keep-file-path: false\n" +
-        "  ignore-failed-tests: false\n" +
-        "  disable-sharding: false\n" +
-        "  smart-flank-disable-upload: false\n" +
-        "  legacy-junit-result: false\n" +
-        "  full-junit-result: false\n" +
-        "  output-style: single\n",
-      yamlWriter.writeFlankProperties(extension)
-    )
+    assertThat(extension).containsMatch("num-test-runs: 5")
   }
 
   @Test
@@ -387,75 +288,37 @@ class YamlWriterTest {
     val extension = emptyExtension {
       testShards.set(5)
       repeatTests.set(2)
-    }
+    }.toFlankProperties()
 
-    assertEquals(
-      "flank:\n" +
-        "  max-test-shards: 5\n" +
-        "  num-test-runs: 2\n" +
-        "  keep-file-path: false\n" +
-        "  ignore-failed-tests: false\n" +
-        "  disable-sharding: false\n" +
-        "  smart-flank-disable-upload: false\n" +
-        "  legacy-junit-result: false\n" +
-        "  full-junit-result: false\n" +
-        "  output-style: single\n",
-      yamlWriter.writeFlankProperties(extension)
-    )
+    assertThat(extension).containsMatch("num-test-runs: 2")
+    assertThat(extension).containsMatch("max-test-shards: 5")
   }
 
   @Test
   fun writeResultsHistoryName() {
     val extension = emptyExtension {
       resultsHistoryName.set("androidtest")
-    }
+    }.toAdditionalProperties()
 
-    assertEquals(
-      "  use-orchestrator: false\n" +
-        "  auto-google-login: false\n" +
-        "  record-video: true\n" +
-        "  performance-metrics: true\n" +
-        "  timeout: 15m\n" +
-        "  results-history-name: androidtest\n" +
-        "  num-flaky-test-attempts: 0\n",
-      yamlWriter.writeAdditionalProperties(extension)
-    )
+    assertThat(extension).containsMatch("results-history-name: androidtest")
   }
 
   @Test
   fun writeResultsBucket() {
     val extension = emptyExtension {
       resultsBucket.set("fake-project.appspot.com")
-    }
+    }.toAdditionalProperties()
 
-    assertEquals(
-      "  use-orchestrator: false\n" +
-        "  auto-google-login: false\n" +
-        "  record-video: true\n" +
-        "  performance-metrics: true\n" +
-        "  timeout: 15m\n" +
-        "  results-bucket: fake-project.appspot.com\n" +
-        "  num-flaky-test-attempts: 0\n",
-      yamlWriter.writeAdditionalProperties(extension)
-    )
+    assertThat(extension).containsMatch("results-bucket: fake-project.appspot.com")
   }
 
   @Test
   fun writeResultsDir() {
     val extension = emptyExtension {
       resultsDir.set("resultsGoHere")
-    }
+    }.toAdditionalProperties()
 
-    assertEquals(
-      "  use-orchestrator: false\n" +
-        "  auto-google-login: false\n" +
-        "  record-video: true\n" +
-        "  performance-metrics: true\n" +
-        "  timeout: 15m\n" +
-        "  num-flaky-test-attempts: 0\n" +
-        "  results-dir: resultsGoHere\n",
-      yamlWriter.writeAdditionalProperties(extension)
-    )
+    assertThat(extension).containsMatch("results-dir: resultsGoHere")
   }
 
   @Test
@@ -467,35 +330,22 @@ class YamlWriterTest {
           listOf("class com.example.Foo")
         }
       )
-    }
+    }.toAdditionalProperties()
 
-    assertEquals(
-      "  use-orchestrator: false\n" +
-        "  auto-google-login: false\n" +
-        "  record-video: true\n" +
-        "  performance-metrics: true\n" +
-        "  timeout: 15m\n" +
-        "  results-history-name: androidtest\n" +
-        "  test-targets:\n" +
-        "  - class com.example.Foo\n" +
-        "  num-flaky-test-attempts: 0\n",
-      yamlWriter.writeAdditionalProperties(extension)
+    assertThat(extension).containsMatch("results-history-name: androidtest")
+    assertThat(extension).containsMatch(
+      """
+    |  test-targets:
+    |  - class com.example.Foo
+      """.trimMargin()
     )
   }
 
   @Test
   fun writeNoTestTargets() {
-    val extension = emptyExtension {}
+    val extension = emptyExtension {}.toAdditionalProperties()
 
-    assertEquals(
-      "  use-orchestrator: false\n" +
-        "  auto-google-login: false\n" +
-        "  record-video: true\n" +
-        "  performance-metrics: true\n" +
-        "  timeout: 15m\n" +
-        "  num-flaky-test-attempts: 0\n",
-      yamlWriter.writeAdditionalProperties(extension)
-    )
+    assertThat(extension).doesNotContain("additional-test-apks")
   }
 
   @Test
@@ -506,18 +356,13 @@ class YamlWriterTest {
           listOf("class com.example.Foo#testThing")
         }
       )
-    }
+    }.toAdditionalProperties()
 
-    assertEquals(
-      "  use-orchestrator: false\n" +
-        "  auto-google-login: false\n" +
-        "  record-video: true\n" +
-        "  performance-metrics: true\n" +
-        "  timeout: 15m\n" +
-        "  test-targets:\n" +
-        "  - class com.example.Foo#testThing\n" +
-        "  num-flaky-test-attempts: 0\n",
-      yamlWriter.writeAdditionalProperties(extension)
+    assertThat(extension).containsMatch(
+      """
+    |  test-targets:
+    |  - class com.example.Foo#testThing
+      """.trimMargin()
     )
   }
 
@@ -529,19 +374,14 @@ class YamlWriterTest {
           listOf("class com.example.Foo#testThing", "class com.example.Foo#testThing2")
         }
       )
-    }
+    }.toAdditionalProperties()
 
-    assertEquals(
-      "  use-orchestrator: false\n" +
-        "  auto-google-login: false\n" +
-        "  record-video: true\n" +
-        "  performance-metrics: true\n" +
-        "  timeout: 15m\n" +
-        "  test-targets:\n" +
-        "  - class com.example.Foo#testThing\n" +
-        "  - class com.example.Foo#testThing2\n" +
-        "  num-flaky-test-attempts: 0\n",
-      yamlWriter.writeAdditionalProperties(extension)
+    assertThat(extension).containsMatch(
+      """
+    |  test-targets:
+    |  - class com.example.Foo#testThing
+    |  - class com.example.Foo#testThing2
+      """.trimMargin()
     )
   }
 
@@ -549,20 +389,9 @@ class YamlWriterTest {
   fun writeSmartFlankGcsPath() {
     val extension = emptyExtension {
       smartFlankGcsPath.set("gs://test/fakepath.xml")
-    }
+    }.toFlankProperties()
 
-    assertEquals(
-      "flank:\n" +
-        "  smart-flank-gcs-path: gs://test/fakepath.xml\n" +
-        "  keep-file-path: false\n" +
-        "  ignore-failed-tests: false\n" +
-        "  disable-sharding: false\n" +
-        "  smart-flank-disable-upload: false\n" +
-        "  legacy-junit-result: false\n" +
-        "  full-junit-result: false\n" +
-        "  output-style: single\n",
-      yamlWriter.writeFlankProperties(extension)
-    )
+    assertThat(extension).containsMatch("smart-flank-gcs-path: gs://test/fakepath.xml")
   }
 
   @Test
@@ -573,17 +402,9 @@ class YamlWriterTest {
           emptyList<String>()
         }
       )
-    }
+    }.toAdditionalProperties()
 
-    assertEquals(
-      "  use-orchestrator: false\n" +
-        "  auto-google-login: false\n" +
-        "  record-video: true\n" +
-        "  performance-metrics: true\n" +
-        "  timeout: 15m\n" +
-        "  num-flaky-test-attempts: 0\n",
-      yamlWriter.writeAdditionalProperties(extension)
-    )
+    assertThat(extension).doesNotContain("directories-to-pull")
   }
 
   @Test
@@ -594,18 +415,13 @@ class YamlWriterTest {
           listOf("/sdcard/screenshots")
         }
       )
-    }
+    }.toAdditionalProperties()
 
-    assertEquals(
-      "  use-orchestrator: false\n" +
-        "  auto-google-login: false\n" +
-        "  record-video: true\n" +
-        "  performance-metrics: true\n" +
-        "  timeout: 15m\n" +
-        "  directories-to-pull:\n" +
-        "  - /sdcard/screenshots\n" +
-        "  num-flaky-test-attempts: 0\n",
-      yamlWriter.writeAdditionalProperties(extension)
+    assertThat(extension).containsMatch(
+      """
+    |  directories-to-pull:
+    |  - /sdcard/screenshots
+      """.trimMargin()
     )
   }
 
@@ -617,19 +433,14 @@ class YamlWriterTest {
           listOf("/sdcard/screenshots", "/sdcard/reports")
         }
       )
-    }
+    }.toAdditionalProperties()
 
-    assertEquals(
-      "  use-orchestrator: false\n" +
-        "  auto-google-login: false\n" +
-        "  record-video: true\n" +
-        "  performance-metrics: true\n" +
-        "  timeout: 15m\n" +
-        "  directories-to-pull:\n" +
-        "  - /sdcard/screenshots\n" +
-        "  - /sdcard/reports\n" +
-        "  num-flaky-test-attempts: 0\n",
-      yamlWriter.writeAdditionalProperties(extension)
+    assertThat(extension).containsMatch(
+      """
+    |  directories-to-pull:
+    |  - /sdcard/screenshots
+    |  - /sdcard/reports
+      """.trimMargin()
     )
   }
 
@@ -641,19 +452,9 @@ class YamlWriterTest {
           emptyList<String>()
         }
       )
-    }
+    }.toFlankProperties()
 
-    assertEquals(
-      "flank:\n" +
-        "  keep-file-path: false\n" +
-        "  ignore-failed-tests: false\n" +
-        "  disable-sharding: false\n" +
-        "  smart-flank-disable-upload: false\n" +
-        "  legacy-junit-result: false\n" +
-        "  full-junit-result: false\n" +
-        "  output-style: single\n",
-      yamlWriter.writeFlankProperties(extension)
-    )
+    assertThat(extension).doesNotContain("files-to-download")
   }
 
   @Test
@@ -664,20 +465,13 @@ class YamlWriterTest {
           listOf(".*/screenshots/.*")
         }
       )
-    }
+    }.toFlankProperties()
 
-    assertEquals(
-      "flank:\n" +
-        "  keep-file-path: false\n" +
-        "  files-to-download:\n" +
-        "  - .*/screenshots/.*\n" +
-        "  ignore-failed-tests: false\n" +
-        "  disable-sharding: false\n" +
-        "  smart-flank-disable-upload: false\n" +
-        "  legacy-junit-result: false\n" +
-        "  full-junit-result: false\n" +
-        "  output-style: single\n",
-      yamlWriter.writeFlankProperties(extension)
+    assertThat(extension).containsMatch(
+      """
+    |  files-to-download:
+    |  - .*/screenshots/.*
+      """.trimMargin()
     )
   }
 
@@ -689,21 +483,14 @@ class YamlWriterTest {
           listOf(".*/screenshots/.*", ".*/reports/.*")
         }
       )
-    }
+    }.toFlankProperties()
 
-    assertEquals(
-      "flank:\n" +
-        "  keep-file-path: false\n" +
-        "  files-to-download:\n" +
-        "  - .*/screenshots/.*\n" +
-        "  - .*/reports/.*\n" +
-        "  ignore-failed-tests: false\n" +
-        "  disable-sharding: false\n" +
-        "  smart-flank-disable-upload: false\n" +
-        "  legacy-junit-result: false\n" +
-        "  full-junit-result: false\n" +
-        "  output-style: single\n",
-      yamlWriter.writeFlankProperties(extension)
+    assertThat(extension).containsMatch(
+      """
+    |  files-to-download:
+    |  - .*/screenshots/.*
+    |  - .*/reports/.*
+      """.trimMargin()
     )
   }
 
@@ -717,18 +504,13 @@ class YamlWriterTest {
           )
         }
       )
-    }
+    }.toAdditionalProperties()
 
-    assertEquals(
-      "  use-orchestrator: false\n" +
-        "  auto-google-login: false\n" +
-        "  record-video: true\n" +
-        "  performance-metrics: true\n" +
-        "  timeout: 15m\n" +
-        "  environment-variables:\n" +
-        "    listener: com.osacky.flank.sample.Listener\n" +
-        "  num-flaky-test-attempts: 0\n",
-      yamlWriter.writeAdditionalProperties(extension)
+    assertThat(extension).containsMatch(
+      """
+    |  environment-variables:
+    |    listener: com.osacky.flank.sample.Listener
+      """.trimMargin()
     )
   }
 
@@ -743,77 +525,31 @@ class YamlWriterTest {
           )
         }
       )
-    }
+    }.toAdditionalProperties()
 
-    assertEquals(
-      "  use-orchestrator: false\n" +
-        "  auto-google-login: false\n" +
-        "  record-video: true\n" +
-        "  performance-metrics: true\n" +
-        "  timeout: 15m\n" +
-        "  environment-variables:\n" +
-        "    clearPackageData: true\n" +
-        "    listener: com.osacky.flank.sample.Listener\n" +
-        "  num-flaky-test-attempts: 0\n",
-      yamlWriter.writeAdditionalProperties(extension)
-    )
-  }
-
-  @Test
-  fun writeDefaultProperties() {
-    val extension = emptyExtension {
-      useOrchestrator.set(true)
-      autoGoogleLogin.set(true)
-      recordVideo.set(false)
-      performanceMetrics.set(false)
-      testTimeout.set("45m")
-    }
-
-    assertEquals(
-      "  use-orchestrator: true\n" +
-        "  auto-google-login: true\n" +
-        "  record-video: false\n" +
-        "  performance-metrics: false\n" +
-        "  timeout: 45m\n" +
-        "  num-flaky-test-attempts: 0\n",
-      yamlWriter.writeAdditionalProperties(extension)
+    assertThat(extension).containsMatch(
+      """
+    |  environment-variables:
+    |    clearPackageData: true
+    |    listener: com.osacky.flank.sample.Listener
+      """.trimMargin()
     )
   }
 
   @Test
   fun writeNoKeepFilePath() {
-    val extension = emptyExtension()
+    val extension = emptyExtension().toFlankProperties()
 
-    assertEquals(
-      "flank:\n" +
-        "  keep-file-path: false\n" +
-        "  ignore-failed-tests: false\n" +
-        "  disable-sharding: false\n" +
-        "  smart-flank-disable-upload: false\n" +
-        "  legacy-junit-result: false\n" +
-        "  full-junit-result: false\n" +
-        "  output-style: single\n",
-      yamlWriter.writeFlankProperties(extension)
-    )
+    assertThat(extension).doesNotContain("keep-file-path")
   }
 
   @Test
   fun writeKeepFilePath() {
     val extension = emptyExtension {
       keepFilePath.set(true)
-    }
+    }.toFlankProperties()
 
-    assertThat(yamlWriter.writeFlankProperties(extension))
-      .isEqualTo(
-        "flank:\n" +
-          "  keep-file-path: true\n" +
-          "  ignore-failed-tests: false\n" +
-          "  disable-sharding: false\n" +
-          "  smart-flank-disable-upload: false\n" +
-          "  legacy-junit-result: false\n" +
-          "  full-junit-result: false\n" +
-          "  output-style: single\n"
-      )
+    assertThat(extension).containsMatch("keep-file-path: true")
   }
 
   @Test
@@ -833,69 +569,28 @@ class YamlWriterTest {
           )
         }
       )
-    }
+    }.toFlankProperties()
 
-    assertThat(
-      yamlWriter.writeFlankProperties(extension)
-    ).isEqualTo(
+    assertThat(extension).containsMatch(
       """
-             flank:
-               keep-file-path: false
-               additional-app-test-apks:
-                 - app: ../orange/build/output/app.apk
-                   test: ../orange/build/output/app-test2.apk
-                 - app: ../bob/build/output/app.apk
-                   test: ../bob/build/output/app-test.apk
-                 - test: ../bob/build/output/app-test2.apk
-                 - test: ../bob/build/output/app-test3.apk
-               ignore-failed-tests: false
-               disable-sharding: false
-               smart-flank-disable-upload: false
-               legacy-junit-result: false
-               full-junit-result: false
-               output-style: single
-      """.trimIndent() + '\n'
+    |  additional-app-test-apks:
+    |    - app: ../orange/build/output/app.apk
+    |      test: ../orange/build/output/app-test2.apk
+    |    - app: ../bob/build/output/app.apk
+    |      test: ../bob/build/output/app-test.apk
+    |    - test: ../bob/build/output/app-test2.apk
+    |    - test: ../bob/build/output/app-test3.apk
+      """.trimMargin()
     )
-  }
-
-  @Test
-  fun verifyDefaultValues() {
-    val defaultFlankProperties = emptyExtension().toFlankProperties()
-    val defaultAdditionalProperties = emptyExtension().toAdditionalProperties().trimIndent()
-
-    val expectedFlank =
-      """
-      flank:
-        keep-file-path: false
-        ignore-failed-tests: false
-        disable-sharding: false
-        smart-flank-disable-upload: false
-        legacy-junit-result: false
-        full-junit-result: false
-        output-style: single
-      """.trimIndent()
-
-    val expectedAdditional =
-      """
-        use-orchestrator: false
-        auto-google-login: false
-        record-video: true
-        performance-metrics: true
-        timeout: 15m
-        num-flaky-test-attempts: 0
-      """.trimIndent()
-
-    assertEquals(expectedFlank, defaultFlankProperties)
-    assertEquals(expectedAdditional, defaultAdditionalProperties)
   }
 
   @Test
   fun writeRunTimeout() {
     val extension = emptyExtension {
       runTimeout.set("20m")
-    }
+    }.toFlankProperties()
 
-    assertTrue(yamlWriter.writeFlankProperties(extension).contains("  run-timeout: 20m"))
+    assertThat(extension).containsMatch("run-timeout: 20m")
   }
 
   @Test
@@ -904,7 +599,7 @@ class YamlWriterTest {
       ignoreFailedTests.set(true)
     }.toFlankProperties()
 
-    assertTrue(properties.contains("  ignore-failed-tests: true"))
+    assertThat(properties).containsMatch("ignore-failed-tests: true")
   }
 
   @Test
@@ -913,7 +608,7 @@ class YamlWriterTest {
       disableSharding.set(true)
     }.toFlankProperties()
 
-    assertTrue(properties.contains("  disable-sharding: true"))
+    assertThat(properties).containsMatch("disable-sharding: true")
   }
 
   @Test
@@ -922,7 +617,7 @@ class YamlWriterTest {
       smartFlankDisableUpload.set(true)
     }.toFlankProperties()
 
-    assertTrue(properties.contains("  smart-flank-disable-upload: true"))
+    assertThat(properties).containsMatch("smart-flank-disable-upload: true")
   }
 
   @Test
@@ -931,7 +626,7 @@ class YamlWriterTest {
       testRunnerClass.set("any.class.Runner")
     }.toAdditionalProperties()
 
-    assertTrue(properties.contains("  test-runner-class: any.class.Runner"))
+    assertThat(properties).containsMatch("test-runner-class: any.class.Runner")
   }
 
   @Test
@@ -940,7 +635,7 @@ class YamlWriterTest {
       localResultsDir.set("~/my/results/dir")
     }.toFlankProperties()
 
-    assertTrue(properties.contains("  local-result-dir: ~/my/results/dir"))
+    assertThat(properties).containsMatch("local-result-dir: ~/my/results/dir")
   }
 
   @Test
@@ -949,7 +644,7 @@ class YamlWriterTest {
       numUniformShards.set(20)
     }.toAdditionalProperties()
 
-    assertTrue(properties.contains("  num-uniform-shards: 20"))
+    assertThat(properties).containsMatch("num-uniform-shards: 20")
   }
 
   @Test
@@ -958,14 +653,14 @@ class YamlWriterTest {
       outputStyle.set("anyString")
     }.toFlankProperties()
 
-    assertTrue(properties.contains("  output-style: anyString"))
+    assertThat(properties).containsMatch("output-style: anyString")
   }
 
   @Test
   fun missingOutputStyle() {
     val properties = emptyExtension().toFlankProperties()
 
-    assertTrue(properties.contains("  output-style: single"))
+    assertThat(properties).doesNotContainMatch("output-style")
   }
 
   @Test
@@ -974,14 +669,14 @@ class YamlWriterTest {
       legacyJunitResult.set(true)
     }.toFlankProperties()
 
-    assertTrue(properties.contains("  legacy-junit-result: true"))
+    assertThat(properties).containsMatch("legacy-junit-result: true")
   }
 
   @Test
   fun missingLegacyJunitResult() {
     val properties = emptyExtension().toFlankProperties()
 
-    assertTrue(properties.contains("  legacy-junit-result: false"))
+    assertThat(properties).doesNotContainMatch("legacy-junit-result")
   }
 
   @Test
@@ -990,14 +685,14 @@ class YamlWriterTest {
       fullJunitResult.set(true)
     }.toFlankProperties()
 
-    assertTrue(properties.contains("  full-junit-result: true"))
+    assertThat(properties).containsMatch("full-junit-result: true")
   }
 
   @Test
   fun missingFullJunitResult() {
     val properties = emptyExtension().toFlankProperties()
 
-    assertTrue(properties.contains("  full-junit-result: false"))
+    assertThat(properties).doesNotContainMatch("full-junit-result")
   }
 
   @Test
@@ -1013,14 +708,12 @@ class YamlWriterTest {
       )
     }.toAdditionalProperties()
 
-    assertTrue(
-      properties.contains(
-        """
+    assertThat(properties).containsMatch(
+      """
       |  client-details:
       |    anyDetail1: anyValue1
       |    anyDetail2: anyValue2
-    """.trimMargin()
-      )
+      """.trimMargin()
     )
   }
 
@@ -1038,15 +731,13 @@ class YamlWriterTest {
       )
     }.toFlankProperties()
 
-    assertTrue(
-      properties.contains(
-        """
+    assertThat(properties).containsMatch(
+      """
       |  test-targets-always-run:
       |  - class com.example.FirstTests#test1
       |  - class com.example.FirstTests#test2
       |  - class com.example.FirstTests#test3
-    """.trimMargin()
-      )
+      """.trimMargin()
     )
   }
 
@@ -1063,14 +754,12 @@ class YamlWriterTest {
       )
     }.toAdditionalProperties()
 
-    assertTrue(
-      properties.contains(
-        """
+    assertThat(properties).containsMatch(
+      """
         |  other-files:
         |    /example/path/test1: anyfile.txt
         |    /example/path/test2: anyfile2.txt
-    """.trimMargin()
-      )
+      """.trimMargin()
     )
   }
 
@@ -1080,7 +769,7 @@ class YamlWriterTest {
       networkProfile.set("LTE")
     }.toAdditionalProperties()
 
-    assertTrue(properties.contains("  network-profile: LTE"))
+    assertThat(properties).containsMatch("network-profile: LTE")
   }
 
   @Test
@@ -1089,7 +778,7 @@ class YamlWriterTest {
       roboScript.set("~/my/dir/with/script.json")
     }.toAdditionalProperties()
 
-    assertTrue(properties.contains("  robo-script: ~/my/dir/with/script.json"))
+    assertThat(properties).containsMatch("robo-script: ~/my/dir/with/script.json")
   }
 
   @Test
@@ -1106,15 +795,13 @@ class YamlWriterTest {
       )
     }.toAdditionalProperties()
 
-    assertTrue(
-      properties.contains(
-        """
+    assertThat(properties).containsMatch(
+      """
         |  robo-directives:
         |    click:button3: ""
         |    ignore:button1: ""
         |    text:field1: my common text
-    """.trimMargin()
-      )
+      """.trimMargin()
     )
   }
 

--- a/buildSrc/src/test/java/com/osacky/flank/gradle/integration/AutoConfigureFladleTest.kt
+++ b/buildSrc/src/test/java/com/osacky/flank/gradle/integration/AutoConfigureFladleTest.kt
@@ -61,25 +61,13 @@ class AutoConfigureFladleTest {
             version: 23
 
           use-orchestrator: true
-          auto-google-login: false
-          record-video: true
-          performance-metrics: true
-          timeout: 15m
           environment-variables:
             clearPackageData: true
           test-targets:
           - class com.osacky.flank.gradle.sample.ExampleInstrumentedTest#seeView
-          num-flaky-test-attempts: 0
 
         flank:
           smart-flank-gcs-path: gs://test-lab-yr9w6qsdvy45q-iurp80dm95h8a/flank/test_app_android.xml
-          keep-file-path: false
-          ignore-failed-tests: false
-          disable-sharding: false
-          smart-flank-disable-upload: false
-          legacy-junit-result: false
-          full-junit-result: false
-          output-style: single
       """.trimIndent()
     )
   }

--- a/buildSrc/src/test/java/com/osacky/flank/gradle/integration/SanityRoboTest.kt
+++ b/buildSrc/src/test/java/com/osacky/flank/gradle/integration/SanityRoboTest.kt
@@ -205,29 +205,12 @@ class SanityRoboTest {
       |gcloud:
       |  app: foo.apk
       |  test: test.apk
-      |  device:
-      |  - model: NexusLowRes
-      |    version: 28
-      |
-      |  use-orchestrator: false
-      |  auto-google-login: false
-      |  record-video: true
-      |  performance-metrics: true
-      |  timeout: 15m
-      |  num-flaky-test-attempts: 0
       |
       |flank:
-      |  keep-file-path: false
       |  additional-app-test-apks:
       |    - app: debug2.apk
       |      test: test2.apk
       |    - test: test3.apk
-      |  ignore-failed-tests: false
-      |  disable-sharding: false
-      |  smart-flank-disable-upload: false
-      |  legacy-junit-result: false
-      |  full-junit-result: false
-      |  output-style: single
     """.trimMargin()
     )
 
@@ -238,25 +221,8 @@ class SanityRoboTest {
       """
       |gcloud:
       |  app: foo.apk
-      |  device:
-      |  - model: NexusLowRes
-      |    version: 28
-      |
-      |  use-orchestrator: false
-      |  auto-google-login: false
-      |  record-video: true
-      |  performance-metrics: true
-      |  timeout: 15m
-      |  num-flaky-test-attempts: 0
       |
       |flank:
-      |  keep-file-path: false
-      |  ignore-failed-tests: false
-      |  disable-sharding: false
-      |  smart-flank-disable-upload: false
-      |  legacy-junit-result: false
-      |  full-junit-result: false
-      |  output-style: single
     """.trimMargin()
     )
   }
@@ -296,25 +262,8 @@ class SanityRoboTest {
       """
       |gcloud:
       |  app: foo.apk
-      |  device:
-      |  - model: NexusLowRes
-      |    version: 28
-      |
-      |  use-orchestrator: false
-      |  auto-google-login: false
-      |  record-video: true
-      |  performance-metrics: true
-      |  timeout: 15m
-      |  num-flaky-test-attempts: 0
       |
       |flank:
-      |  keep-file-path: false
-      |  ignore-failed-tests: false
-      |  disable-sharding: false
-      |  smart-flank-disable-upload: false
-      |  legacy-junit-result: false
-      |  full-junit-result: false
-      |  output-style: single
     """.trimMargin()
     )
 
@@ -326,29 +275,12 @@ class SanityRoboTest {
       |gcloud:
       |  app: foo.apk
       |  test: test.apk
-      |  device:
-      |  - model: NexusLowRes
-      |    version: 28
-      |
-      |  use-orchestrator: false
-      |  auto-google-login: false
-      |  record-video: true
-      |  performance-metrics: true
-      |  timeout: 15m
-      |  num-flaky-test-attempts: 0
       |
       |flank:
-      |  keep-file-path: false
       |  additional-app-test-apks:
       |    - app: debug2.apk
       |      test: test2.apk
       |    - test: test3.apk
-      |  ignore-failed-tests: false
-      |  disable-sharding: false
-      |  smart-flank-disable-upload: false
-      |  legacy-junit-result: false
-      |  full-junit-result: false
-      |  output-style: single
     """.trimMargin()
     )
   }

--- a/buildSrc/src/test/java/com/osacky/flank/gradle/integration/SanityWithAutoConfigureTest.kt
+++ b/buildSrc/src/test/java/com/osacky/flank/gradle/integration/SanityWithAutoConfigureTest.kt
@@ -97,25 +97,13 @@ class SanityWithAutoConfigureTest {
             version: 23
 
           use-orchestrator: true
-          auto-google-login: false
-          record-video: true
-          performance-metrics: true
-          timeout: 15m
           environment-variables:
             clearPackageData: true
           test-targets:
           - class com.osacky.flank.gradle.sample.ExampleInstrumentedTest#seeView
-          num-flaky-test-attempts: 0
 
         flank:
           smart-flank-gcs-path: gs://test-lab-yr9w6qsdvy45q-iurp80dm95h8a/flank/test_app_android.xml
-          keep-file-path: false
-          ignore-failed-tests: false
-          disable-sharding: false
-          smart-flank-disable-upload: false
-          legacy-junit-result: false
-          full-junit-result: false
-          output-style: single
       """.trimIndent()
     )
 
@@ -133,10 +121,6 @@ class SanityWithAutoConfigureTest {
             version: 23
 
           use-orchestrator: false
-          auto-google-login: false
-          record-video: true
-          performance-metrics: true
-          timeout: 15m
           environment-variables:
             clearPackageData: true
           test-targets:
@@ -145,13 +129,6 @@ class SanityWithAutoConfigureTest {
 
         flank:
           smart-flank-gcs-path: gs://test-lab-yr9w6qsdvy45q-iurp80dm95h8a/flank/test_app_android.xml
-          keep-file-path: false
-          ignore-failed-tests: false
-          disable-sharding: false
-          smart-flank-disable-upload: false
-          legacy-junit-result: false
-          full-junit-result: false
-          output-style: single
       """.trimIndent()
     )
 
@@ -170,10 +147,6 @@ class SanityWithAutoConfigureTest {
             version: 23
 
           use-orchestrator: false
-          auto-google-login: false
-          record-video: true
-          performance-metrics: true
-          timeout: 15m
           environment-variables:
             clearPackageData: true
           test-targets:
@@ -182,13 +155,6 @@ class SanityWithAutoConfigureTest {
 
         flank:
           smart-flank-gcs-path: gs://test-lab-yr9w6qsdvy45q-iurp80dm95h8a/flank/test_app_android.xml
-          keep-file-path: false
-          ignore-failed-tests: false
-          disable-sharding: false
-          smart-flank-disable-upload: false
-          legacy-junit-result: false
-          full-junit-result: false
-          output-style: single
       """.trimIndent()
     )
   }
@@ -244,25 +210,13 @@ class SanityWithAutoConfigureTest {
             version: 23
 
           use-orchestrator: true
-          auto-google-login: false
-          record-video: true
-          performance-metrics: true
-          timeout: 15m
           environment-variables:
             clearPackageData: true
           test-targets:
           - class com.osacky.flank.gradle.sample.ExampleInstrumentedTest#seeView
-          num-flaky-test-attempts: 0
 
         flank:
           smart-flank-gcs-path: gs://test-lab-yr9w6qsdvy45q-iurp80dm95h8a/flank/test_app_android.xml
-          keep-file-path: false
-          ignore-failed-tests: false
-          disable-sharding: false
-          smart-flank-disable-upload: false
-          legacy-junit-result: false
-          full-junit-result: false
-          output-style: single
       """.trimIndent()
     )
 
@@ -281,10 +235,6 @@ class SanityWithAutoConfigureTest {
             version: 23
 
           use-orchestrator: false
-          auto-google-login: false
-          record-video: true
-          performance-metrics: true
-          timeout: 15m
           environment-variables:
             clearPackageData: true
           test-targets:
@@ -293,13 +243,6 @@ class SanityWithAutoConfigureTest {
 
         flank:
           smart-flank-gcs-path: gs://test-lab-yr9w6qsdvy45q-iurp80dm95h8a/flank/test_app_android.xml
-          keep-file-path: false
-          ignore-failed-tests: false
-          disable-sharding: false
-          smart-flank-disable-upload: false
-          legacy-junit-result: false
-          full-junit-result: false
-          output-style: single
       """.trimIndent()
     )
   }


### PR DESCRIPTION
### Fladle should relay on flank's default values. (proposal)
Both fladle and flank have some default values implemented, most of them are the same. The only differences I found:
|Option|Fladle|Flank|
| ------------- | ------------- |------------- |
| `recordVideo`  | `true` |`false`|
| `outputStyle`  | `single`  |`multi`|
| `performanceMetrics`  | `true`  |`false`|

This change would make a bit easier to implement new options and maintain test code