### PR TITLE
Move responsibility to FlankExecutionTask and declare inputs

### DIFF
--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FladlePluginDelegate.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FladlePluginDelegate.kt
@@ -81,19 +81,14 @@ class FladlePluginDelegate {
       dependsOn(writeConfigProps)
     }
 
-    val execFlank = register("execFlank$name", FlankExecutionTask::class.java, config)
+    val execFlank = register("execFlank$name", FlankExecutionTask::class.java)
     execFlank.configure {
-      description = "Runs instrumentation tests using flank on firebase test lab."
-      classpath = project.fladleConfig
-      args = if (project.hasProperty("dumpShards")) {
-        listOf("firebase", "test", "android", "run", "-c", writeConfigProps.get().fladleConfigFile.get().asFile.absolutePath, "--dump-shards")
-      } else {
-        listOf("firebase", "test", "android", "run", "-c", writeConfigProps.get().fladleConfigFile.get().asFile.absolutePath)
-      }
-      if (config.serviceAccountCredentials.isPresent) {
-        environment(mapOf("GOOGLE_APPLICATION_CREDENTIALS" to config.serviceAccountCredentials.get()))
-      }
+      dumpShards.set(project.hasProperty("dumpShards"))
+      serviceAccountCredentials.set(config.serviceAccountCredentials)
+
+      fladleConfig.from(project.fladleConfig)
       dependsOn(writeConfigProps)
+      yamlFile.value(writeConfigProps.flatMap { it.fladleConfigFile })
     }
 
     register("runFlank$name", RunFlankTask::class.java).configure {

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FlankExecutionTask.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FlankExecutionTask.kt
@@ -1,19 +1,72 @@
 package com.osacky.flank.gradle
 
+import org.gradle.api.DefaultTask
 import org.gradle.api.file.ProjectLayout
+import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.JavaExec
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.kotlin.dsl.property
+import org.gradle.process.ExecOperations
 import javax.inject.Inject
 
-open class FlankExecutionTask @Inject constructor(projectLayout: ProjectLayout, private val config: FladleConfig) : FlankJavaExec(projectLayout) {
+open class FlankExecutionTask @Inject constructor(
+  objectFactory: ObjectFactory,
+  private val projectLayout: ProjectLayout,
+  private val execOperations: ExecOperations
+) : DefaultTask() {
+  @get:Input
+  val dumpShards: Property<Boolean> = objectFactory.property<Boolean>().convention(false)
+
+  @get:InputFile
+  val serviceAccountCredentials: Property<RegularFile> = objectFactory.fileProperty()
+
+  @Suppress("unused")
+  @get:InputFile
+  @PathSensitive(PathSensitivity.RELATIVE)
+  val yamlFile: RegularFileProperty = objectFactory.fileProperty()
+
+  @get:InputFiles
+  @Classpath
+  val fladleConfig = objectFactory.fileCollection()
 
   init {
-    doFirst {
-      checkFilesExist(config)
+    group = JavaExec.TASK_GROUP
+    description = "Runs instrumentation tests using flank on firebase test lab."
+
+    outputs.upToDateWhen {
+      false
     }
   }
 
-  private fun checkFilesExist(base: FladleConfig) {
-    if (base.serviceAccountCredentials.isPresent) {
-      check(base.serviceAccountCredentials.get().asFile.exists()) { "serviceAccountCredential file doesn't exist ${base.serviceAccountCredentials.get()}" }
+  @TaskAction
+  fun run() {
+    if (serviceAccountCredentials.isPresent) {
+      check(serviceAccountCredentials.get().asFile.exists()) { "serviceAccountCredential file doesn't exist ${serviceAccountCredentials.get()}" }
     }
+
+    execOperations.javaexec {
+      classpath = fladleConfig
+      args = if (dumpShards.get()) {
+        listOf("firebase", "test", "android", "run", "--dump-shards")
+      } else {
+        listOf("firebase", "test", "android", "run")
+      }
+
+      if (serviceAccountCredentials.isPresent) {
+        environment(mapOf("GOOGLE_APPLICATION_CREDENTIALS" to serviceAccountCredentials.get()))
+      }
+
+      main = "ftl.Main"
+      workingDir(projectLayout.fladleDir)
+    }.assertNormalExitValue()
   }
 }


### PR DESCRIPTION
It requires to merge #160 

This PR is still in the way of making UI Tests cacheable (opt-in), declaring inputs helps, even if we still are missing the outputs and the most important part, adding the APKs and testAPKs as inputs too.