### PR TITLE
Fix `flankAuth` not creating output directory.

### DIFF
--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FladlePluginDelegate.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FladlePluginDelegate.kt
@@ -21,6 +21,9 @@ class FladlePluginDelegate {
     val extension = target.extensions.create<FlankGradleExtension>("fladle", target.objects)
 
     target.tasks.register("flankAuth", FlankJavaExec::class.java) {
+      doFirst {
+        target.layout.fladleDir.get().asFile.mkdirs()
+      }
       classpath = project.fladleConfig
       args = listOf("auth", "login")
     }

--- a/buildSrc/src/test/java/com/osacky/flank/gradle/integration/FlankAuthTestTask.kt
+++ b/buildSrc/src/test/java/com/osacky/flank/gradle/integration/FlankAuthTestTask.kt
@@ -1,0 +1,34 @@
+package com.osacky.flank.gradle.integration
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class FlankAuthTestTask {
+  @get:Rule
+  var testProjectRoot = TemporaryFolder()
+
+  @Test
+  fun testFlankAuth() {
+    // We set a task timeout because running flankAuth opens a link in the web browser.
+    // We want the task to fail from the timeout and not any other reason like a missing folder.
+    testProjectRoot.writeBuildDotGradle(
+      """plugins {
+         |  id "com.osacky.fladle"
+         |}
+         |repositories {
+         |  mavenCentral()
+         |}
+         |
+         |tasks.named("flankAuth").configure {
+         |  timeout.set(Duration.ofSeconds(5))
+         |}
+         |""".trimMargin()
+    )
+
+    val result = testProjectRoot.gradleRunner().withArguments("flankAuth").buildAndFail()
+
+    assertThat(result.output).contains("Visit the following URL in your browser:")
+  }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+
+## 0.13.1
+* Fix flankAuth task throwing exception. [Fixes #195](https://github.com/runningcode/fladle/issues/195)
 * Add support for newly added flank options [PR#186](https://github.com/runningcode/fladle/pull/186) Thanks [pawelpasterz](https://github.com/pawelpasterz): 
     * `default-test-time`
     * `default-class-test-time`


### PR DESCRIPTION
Flank expects the output directory to already exists.

Fixes #195
