### PR TITLE
Update fladle options

### DIFF
--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FladleConfig.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FladleConfig.kt
@@ -25,6 +25,7 @@ interface FladleConfig {
   @get:Input
   @get:Optional
   val debugApk: Property<String>
+
   @get:Input
   @get:Optional
   val instrumentationApk: Property<String>
@@ -331,4 +332,74 @@ interface FladleConfig {
   @get:Input
   @get:Optional
   val testTargetsForShard: ListProperty<String>
+
+  /**
+   * Whether to grant runtime permissions on the device before the test begins.
+   * By default, all permissions are granted. PERMISSIONS must be one of: all, none
+   * (default: all)
+   */
+  @get:SinceFlank("20.12.0")
+  @get:Input
+  @get:Optional
+  val grantPermissions: Property<String>
+
+  /**
+   * The type of test to run. TYPE must be one of: instrumentation, robo, game-loop.
+   * Use if you want to be sure there is only one type of tests being run
+   * (flank enables to run mixed types of test in one run).
+   */
+  @get:SinceFlank("20.12.0")
+  @get:Input
+  @get:Optional
+  val type: Property<String>
+
+  /**
+   * A list of game-loop scenario labels (default: None). Each game-loop scenario may be labeled in the
+   * APK manifest file with one or more arbitrary strings, creating logical groupings (e.g. GPU_COMPATIBILITY_TESTS).
+   * If --scenario-numbers and --scenario-labels are specified together, Firebase Test Lab will first execute each scenario from --scenario-numbers.
+   * It will then expand each given scenario label into a list of scenario numbers marked with that label, and execute those scenarios.
+   */
+  @get:SinceFlank("20.12.0")
+  @get:Input
+  @get:Optional
+  val scenarioLabels: ListProperty<String>
+
+  /**
+   * A list of game-loop scenario numbers which will be run as part of the test (default: all scenarios).
+   * A maximum of 1024 scenarios may be specified in one test matrix, but the maximum number may also be limited by the overall test --timeout setting.
+   */
+  @get:SinceFlank("20.12.0")
+  @get:Input
+  @get:Optional
+  val scenarioNumbers: ListProperty<Int>
+
+  /**
+   * A list of one or two Android OBB file names which will be copied to each test device before the tests will run (default: None).
+   * Each OBB file name must conform to the format as specified by Android (e.g. [main|patch].0300110.com.example.android.obb) and will be installed into <shared-storage>/Android/obb/<package-name>/ on the test device.
+   */
+  @get:SinceFlank("20.12.0")
+  @get:Input
+  @get:Optional
+  val obbFiles: ListProperty<String>
+
+  /**
+   * A list of OBB required filenames. OBB file name must conform to the format as specified by Android e.g.
+   * [main|patch].0300110.com.example.android.obb which will be installed into <shared-storage>/Android/obb/<package-name>/ on the device.
+   */
+  @get:SinceFlank("20.12.0")
+  @get:Input
+  @get:Optional
+  val obbNames: ListProperty<String>
+
+  /**
+   * If true, only a single attempt at most will be made to run each execution/shard in the matrix.
+   * Flaky test attempts are not affected. Normally, 2 or more attempts are made if a potential
+   * infrastructure issue is detected. This feature is for latency sensitive workloads. The
+   * incidence of execution failures may be significantly greater for fail-fast matrices and support
+   * is more limited because of that expectation.
+   */
+  @get:SinceFlank("21.01.0")
+  @get:Input
+  @get:Optional
+  val failFast: Property<Boolean>
 }

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FladleConfigImpl.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FladleConfigImpl.kt
@@ -53,8 +53,7 @@ data class FladleConfigImpl(
   override val useAverageTestTimeForNewTests: Property<Boolean>,
   override val defaultClassTestTime: Property<Double>,
   override val disableResultsUpload: Property<Boolean>,
-  override val testTargetsForShard: ListProperty<String>
-  override val disableResultsUpload: Property<Boolean>,
+  override val testTargetsForShard: ListProperty<String>,
   override val grantPermissions: Property<String>,
   override val type: Property<String>,
   override val scenarioLabels: ListProperty<String>,

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FladleConfigImpl.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FladleConfigImpl.kt
@@ -54,6 +54,14 @@ data class FladleConfigImpl(
   override val defaultClassTestTime: Property<Double>,
   override val disableResultsUpload: Property<Boolean>,
   override val testTargetsForShard: ListProperty<String>
+  override val disableResultsUpload: Property<Boolean>,
+  override val grantPermissions: Property<String>,
+  override val type: Property<String>,
+  override val scenarioLabels: ListProperty<String>,
+  override val scenarioNumbers: ListProperty<Int>,
+  override val obbFiles: ListProperty<String>,
+  override val obbNames: ListProperty<String>,
+  override val failFast: Property<Boolean>
 ) : FladleConfig {
   /**
    * Prepare config to run sanity robo.

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
@@ -184,8 +184,7 @@ open class FlankGradleExtension @Inject constructor(objects: ObjectFactory) : Fl
       defaultTestTime = objects.property<Double>().convention(defaultTestTime),
       defaultClassTestTime = objects.property<Double>().convention(defaultClassTestTime),
       disableResultsUpload = objects.property<Boolean>().convention(disableResultsUpload),
-      testTargetsForShard = objects.listProperty<String>().convention(testTargetsForShard)
-      disableResultsUpload = objects.property<Boolean>().convention(disableResultsUpload),
+      testTargetsForShard = objects.listProperty<String>().convention(testTargetsForShard),
       grantPermissions = objects.property<String>().convention(grantPermissions),
       type = objects.property<String>().convention(type),
       scenarioLabels = objects.listProperty<String>().convention(scenarioLabels),

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
@@ -120,6 +120,20 @@ open class FlankGradleExtension @Inject constructor(objects: ObjectFactory) : Fl
 
   override val testTargetsForShard: ListProperty<String> = objects.listProperty()
 
+  override val grantPermissions: Property<String> = objects.property()
+
+  override val type: Property<String> = objects.property()
+
+  override val scenarioLabels: ListProperty<String> = objects.listProperty()
+
+  override val scenarioNumbers: ListProperty<Int> = objects.listProperty()
+
+  override val obbFiles: ListProperty<String> = objects.listProperty()
+
+  override val obbNames: ListProperty<String> = objects.listProperty()
+
+  override val failFast: Property<Boolean> = objects.property()
+
   @Internal
   val configs: NamedDomainObjectContainer<FladleConfigImpl> = objects.domainObjectContainer(FladleConfigImpl::class.java) {
     FladleConfigImpl(
@@ -171,6 +185,14 @@ open class FlankGradleExtension @Inject constructor(objects: ObjectFactory) : Fl
       defaultClassTestTime = objects.property<Double>().convention(defaultClassTestTime),
       disableResultsUpload = objects.property<Boolean>().convention(disableResultsUpload),
       testTargetsForShard = objects.listProperty<String>().convention(testTargetsForShard)
+      disableResultsUpload = objects.property<Boolean>().convention(disableResultsUpload),
+      grantPermissions = objects.property<String>().convention(grantPermissions),
+      type = objects.property<String>().convention(type),
+      scenarioLabels = objects.listProperty<String>().convention(scenarioLabels),
+      scenarioNumbers = objects.listProperty<Int>().convention(scenarioNumbers),
+      obbFiles = objects.listProperty<String>().convention(obbFiles),
+      obbNames = objects.listProperty<String>().convention(obbNames),
+      failFast = objects.property<Boolean>().convention(failFast)
     )
   }
 

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/YamlWriter.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/YamlWriter.kt
@@ -101,6 +101,14 @@ internal class YamlWriter {
       }
     }
     appendListProperty(config.additionalApks, name = "additional-apks") { appendln("    - $it") }
+    appendProperty(config.grantPermissions, name = "grant-permissions")
+    appendProperty(config.type, name = "type")
+    appendListProperty(config.scenarioLabels, name = "scenario-labels") { appendln("    - $it") }
+    appendListProperty(config.scenarioNumbers, name = "scenario-numbers") { appendln("    - $it") }
+    appendListProperty(config.obbFiles, name = "obb-files") { appendln("    - $it") }
+    appendListProperty(config.obbNames, name = "obb-names") { appendln("    - $it") }
+    appendListProperty(config.testTargetsForShard, name = "test-targets-for-shard") { appendln("    - $it") }
+    appendProperty(config.failFast, name = "fail-fast")
   }
 
   private fun <T> StringBuilder.appendProperty(prop: Property<T>, name: String) {

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/validation/ValidateOptions.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/validation/ValidateOptions.kt
@@ -14,8 +14,6 @@ fun validateOptionsUsed(config: FladleConfig, flank: String) = config::class.mem
       is Property<*> -> prop.isPresent
       is MapProperty<*, *> -> prop.isPresent && prop.get().isNotEmpty()
       is ListProperty<*> -> prop.isPresent && prop.get().isNotEmpty()
-//      is MapProperty<*, *> -> prop.isPresent
-//      is ListProperty<*> -> prop.isPresent
       else -> false
     }
   }

--- a/buildSrc/src/main/java/com/osacky/flank/gradle/validation/ValidateOptions.kt
+++ b/buildSrc/src/main/java/com/osacky/flank/gradle/validation/ValidateOptions.kt
@@ -12,8 +12,10 @@ fun validateOptionsUsed(config: FladleConfig, flank: String) = config::class.mem
   .filter {
     when (val prop = it.call(config)) {
       is Property<*> -> prop.isPresent
-      is MapProperty<*, *> -> prop.isPresent
+      is MapProperty<*, *> -> prop.isPresent && prop.get().isNotEmpty()
       is ListProperty<*> -> prop.isPresent && prop.get().isNotEmpty()
+//      is MapProperty<*, *> -> prop.isPresent
+//      is ListProperty<*> -> prop.isPresent
       else -> false
     }
   }

--- a/buildSrc/src/test/java/com/osacky/flank/gradle/YamlWriterTest.kt
+++ b/buildSrc/src/test/java/com/osacky/flank/gradle/YamlWriterTest.kt
@@ -1191,6 +1191,116 @@ class YamlWriterTest {
     )
   }
 
+  @Test
+  fun writeGrantPermissions() {
+    val properties = emptyExtension {
+      grantPermissions.set("none")
+    }.toAdditionalProperties()
+
+    assertThat(properties).contains("grant-permissions: none")
+  }
+
+  @Test
+  fun writeType() {
+    val properties = emptyExtension {
+      type.set("game-loop")
+    }.toAdditionalProperties()
+
+    assertThat(properties).contains("type: game-loop")
+  }
+
+  @Test
+  fun writeScenarioLabels() {
+    val properties = emptyExtension {
+      scenarioLabels.set(
+        project.provider {
+          listOf("label1", "label2")
+        }
+      )
+    }.toAdditionalProperties()
+
+    assertThat(properties).contains(
+      """
+      |  scenario-labels:
+      |    - label1
+      |    - label2
+      """.trimMargin()
+    )
+  }
+
+  @Test
+  fun writeScenarioNumbers() {
+    val properties = emptyExtension {
+      scenarioNumbers.set(
+        project.provider {
+          listOf(1, 123, 543)
+        }
+      )
+    }.toAdditionalProperties()
+
+    assertThat(properties).contains(
+      """
+      |  scenario-numbers:
+      |    - 1
+      |    - 123
+      |    - 543
+      """.trimMargin()
+    )
+  }
+
+  @Test
+  fun writeObbFiles() {
+    val properties = emptyExtension {
+      obbFiles.set(
+        project.provider {
+          listOf(
+            "local/file/path/test1.obb",
+            "local/file/path/test2.obb"
+          )
+        }
+      )
+    }.toAdditionalProperties()
+
+    assertThat(properties).contains(
+      """
+      |  obb-files:
+      |    - local/file/path/test1.obb
+      |    - local/file/path/test2.obb
+      """.trimMargin()
+    )
+  }
+
+  @Test
+  fun writeObbNames() {
+    val properties = emptyExtension {
+      obbNames.set(
+        project.provider {
+          listOf(
+            "patch.0300110.com.example.android.obb",
+            "patch.0300111.com.example.android.obb"
+          )
+        }
+      )
+    }.toAdditionalProperties()
+
+    assertThat(properties).contains(
+      """
+      |  obb-names:
+      |    - patch.0300110.com.example.android.obb
+      |    - patch.0300111.com.example.android.obb
+      """.trimMargin()
+    )
+  }
+
+  @Test
+  fun writeFailFast() {
+    val properties = emptyExtension {
+      failFast.set(true)
+    }.toAdditionalProperties()
+
+    assertThat(properties).contains("fail-fast: true")
+  }
+
   private fun emptyExtension() = FlankGradleExtension(project.objects)
   private fun emptyExtension(block: FlankGradleExtension.() -> Unit) = emptyExtension().apply(block)
   private fun FlankGradleExtension.toFlankProperties() = yamlWriter.writeFlankProperties(this).trimIndent()

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -132,6 +132,25 @@ fladle {
     disableResultsUpload = true
     grantPermissions = "none"
     type = "game-loop"
+    scenarioLabels = [
+      "label1",
+      "label2" 
+    ]
+    scenarioNumbers = [ 1, 23, 52 ]
+    obbFiles = [
+      "local/file/path/test1.obb",
+      "local/file/path/test2.obb"
+    ]
+    obbNames = [
+      "patch.0300110.com.example.android.obb",
+      "patch.0300111.com.example.android.obb"
+    ]
+    testTargetsForShard = [
+      "package com.package1.for.shard1, com.package2.for.shard1",
+      "class com.foo.ClassForShard2#testMethod1, com.foo.ClassForShard2#testMethod2",
+      "class com.foo.ClassForShard3; package com.package.for.shard3"
+    ]
+    failFast = true
 }
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -130,6 +130,8 @@ fladle {
     defaultClassTestTime = 180.5
     useAverageTestTimeForNewTests = true
     disableResultsUpload = true
+    grantPermissions = "none"
+    type = "game-loop"
 }
 ```
 
@@ -870,4 +872,128 @@ To specify both package and class in the same shard, separate package and class 
         )
       }
     )
+    ```
+
+### grantPermissions
+Whether to grant runtime permissions on the device before the test begins. By default, all permissions are granted. PERMISSIONS must be one of: all, none
+
+=== "Groovy"
+    ``` groovy
+    grantPermissions = "none"
+    ```
+=== "Kotlin"
+    ``` kotlin
+    grantPermissions.set("none")
+    ```
+
+### type
+The type of test to run. TYPE must be one of: instrumentation, robo, game-loop. Use if you want to be sure there is only one type of tests being run (flank enables to run mixed types of test in one run).
+
+=== "Groovy"
+    ``` groovy
+    type = "game-loop"
+    ```
+=== "Kotlin"
+    ``` kotlin
+    type.set("game-loop")
+    ```
+
+### scenarioLabels
+A list of game-loop scenario labels (default: None). Each game-loop scenario may be labeled in the APK manifest file with one or more arbitrary strings, creating logical groupings (e.g. GPU_COMPATIBILITY_TESTS).
+If --scenario-numbers and --scenario-labels are specified together, Firebase Test Lab will first execute each scenario from --scenario-numbers.
+It will then expand each given scenario label into a list of scenario numbers marked with that label, and execute those scenarios.
+
+=== "Groovy"
+    ```
+    scenarioLabels = [
+      "label1",
+      "label2" 
+    ]
+    ```
+=== "Kotlin"
+    ```
+    scenarioLabels.set(
+      project.provider {
+        listOf("label1", "label2")
+      }
+    )
+    ```
+
+### scenarioNumbers
+A list of game-loop scenario numbers which will be run as part of the test (default: all scenarios).
+A maximum of 1024 scenarios may be specified in one test matrix, but the maximum number may also be limited by the overall test --timeout setting.
+
+=== "Groovy"
+    ```
+    scenarioNumbers = [ 1, 23, 52 ]
+    ```
+=== "Kotlin"
+    ```
+    scenarioNumbers.set(
+      project.provider {
+        listOf(1, 23, 52)
+      }
+    )
+    ```
+
+### obbFiles
+A list of one or two Android OBB file names which will be copied to each test device before the tests will run (default: None).
+Each OBB file name must conform to the format as specified by Android (e.g. [main|patch].0300110.com.example.android.obb) and will be installed into <shared-storage>/Android/obb/<package-name>/ on the test device.
+
+=== "Groovy"
+    ```
+    obbFiles = [
+      "local/file/path/test1.obb",
+      "local/file/path/test2.obb"
+    ]
+    ```
+=== "Kotlin"
+    ```
+    obbFiles.set(
+      project.provider {
+        listOf(
+          "local/file/path/test1.obb",
+          "local/file/path/test2.obb"
+        )
+      }
+    )
+    ```
+
+### obbNames
+A list of OBB required filenames. OBB file name must conform to the format as specified by Android e.g.
+[main|patch].0300110.com.example.android.obb which will be installed into <shared-storage>/Android/obb/<package-name>/ on the device.
+
+=== "Groovy"
+    ```
+    obbNames = [
+      "patch.0300110.com.example.android.obb",
+      "patch.0300111.com.example.android.obb"
+    ]
+    ```
+=== "Kotlin"
+    ```
+    obbNames.set(
+      project.provider {
+        listOf(
+          "patch.0300110.com.example.android.obb",
+          "patch.0300111.com.example.android.obb"
+        )
+      }
+    )
+    ```
+
+### failFast
+If true, only a single attempt at most will be made to run each execution/shard in the matrix. Flaky test attempts are not affected.
+Normally, 2 or more attempts are made if a potential infrastructure issue is detected.
+This feature is for latency sensitive workloads. The incidence of execution failures may be significantly greater for
+fail-fast matrices and support is more limited because of that expectation.
+
+=== "Groovy"
+    ```
+    failFast = true
+    ```
+
+=== "Kotlin"
+    ```
+    failFast.set(true)
     ```


### PR DESCRIPTION
Update fladle with newly added options in flank:
* `grant-permissions`
* `type`
* `scenario-labels`
* `scenario-numbers`
* `obb-files`
* `obb-names`
* `test-targets-for-shard`
* `fail-fast`