### PR TITLE
Support new Flank options without updating Fladle

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
---
+* Support new Flank options without updating Fladle [Fixes #146](https://github.com/runningcode/fladle/issues/146) [PR](https://github.com/runningcode/fladle/pull/214) Thanks [piotradamczyk5](https://github.com/piotradamczyk5)
 
 ## 0.14.0
 * Bump Flank version to 21.01.1

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -940,14 +940,14 @@ If `--scenario-numbers` and `--scenario-labels` are specified together, Firebase
 It will then expand each given scenario label into a list of scenario numbers marked with that label, and execute those scenarios.
 
 === "Groovy"
-    ```
+    ```groovy
     scenarioLabels = [
       "label1",
       "label2" 
     ]
     ```
 === "Kotlin"
-    ```
+    ```kotlin
     scenarioLabels.set(
       project.provider {
         listOf("label1", "label2")
@@ -960,11 +960,11 @@ A list of game-loop scenario numbers which will be run as part of the test (defa
 A maximum of 1024 scenarios may be specified in one test matrix, but the maximum number may also be limited by the overall test `--timeout` setting.
 
 === "Groovy"
-    ```
+    ```groovy
     scenarioNumbers = [ 1, 23, 52 ]
     ```
 === "Kotlin"
-    ```
+    ```kotlin
     scenarioNumbers.set(
       project.provider {
         listOf(1, 23, 52)
@@ -977,14 +977,14 @@ A list of one or two Android OBB file names which will be copied to each test de
 Each OBB file name must conform to the format as specified by Android (e.g. `[main|patch].0300110.com.example.android.obb`) and will be installed into `<shared-storage>/Android/obb/<package-name>/` on the test device.
 
 === "Groovy"
-    ```
+    ```groovy
     obbFiles = [
       "local/file/path/test1.obb",
       "local/file/path/test2.obb"
     ]
     ```
 === "Kotlin"
-    ```
+    ```kotlin
     obbFiles.set(
       project.provider {
         listOf(
@@ -1000,14 +1000,14 @@ A list of OBB required filenames. OBB file name must conform to the format as sp
 `[main|patch].0300110.com.example.android.obb` which will be installed into `<shared-storage>/Android/obb/<package-name>/` on the device.
 
 === "Groovy"
-    ```
+    ```groovy
     obbNames = [
       "patch.0300110.com.example.android.obb",
       "patch.0300111.com.example.android.obb"
     ]
     ```
 === "Kotlin"
-    ```
+    ```kotlin
     obbNames.set(
       project.provider {
         listOf(
@@ -1025,75 +1025,77 @@ This feature is for latency sensitive workloads. The incidence of execution fail
 fail-fast matrices and support is more limited because of that expectation.
 
 === "Groovy"
-    ```
+    ```groovy
     failFast = true
     ```
 
 === "Kotlin"
-    ```
+    ```kotlin
     failFast.set(true)
     ```
 
 
-### additionalFlankConfig
+### additionalFlankOptions
 Appending additional option to flank root yaml. This option is useful when you would like to test options before official fladle support is added.
 before it is available on Fladle. Supports both single and multiple properties.
 
-Single property
+Single option
 
 === "Groovy"
-```
-additionalFlankConfig = "new-property: true"
-```
+    ```groovy
+    additionalFlankOptions = "new-property: true"
+    ```
 
 === "Kotlin"
-```
-additionalFlankConfig.set("new-property: true")
-```
+    ```kotlin
+    additionalFlankOptions.set("new-property: true")
+    ```
 
-Multiple properties
+Multiple options
 
 === "Groovy"
-```
-additionalFlankConfig = "new-property: true\nother-new-property: force"
-```
+    ```groovy
+    additionalFlankOptions = "new-property: true\nother-new-property: force"
+    ```
 
 === "Kotlin"
-```
-additionalFlankConfig.set("""
-    new-property: true
-    other-new-property: force
-""".trimIndent())
-```
+    ```kotlin
+    additionalFlankOptions.set("""
+        new-property: true
+        other-new-property: force
+    """.trimIndent())
+    ```
 
-### additionalGcloudConfig
+### additionalGcloudOptions
 Allow appending additional config to gcloud root yaml. This option is useful when you would like to test option
 before it is available on Fladle. Supports both single and multiple properties.
 
 
-Single property
+Single option
 
 === "Groovy"
-```
-additionalGcloudConfig = "new-property: true"
-```
+    ```groovy
+    additionalGcloudOptions = "new-property: true"
+    ```
 
 === "Kotlin"
-```
-additionalGcloudConfig.set("new-property: true")
-```
+    ```kotlin
+    additionalGcloudOptions.set("new-property: true")
+    ```
 
-Multiple properties
+Multiple options
 
 === "Groovy"
-```
-additionalGcloudConfig = "new-property: true\nother-new-property: force"
-```
+    ```groovy
+    additionalGcloudOptions = """
+        new-property: true
+        other-new-property: force""".stripIndent()
+    ```
 
 === "Kotlin"
-```
-additionalGcloudConfig.set("""
-    new-property: true
-    other-new-property: force
-""".trimIndent())
-```
+    ```kotlin
+    additionalGcloudOptions.set("""
+        new-property: true
+        other-new-property: force
+    """.trimIndent())
+    ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1089,7 +1089,8 @@ Multiple options
     ```groovy
     additionalGcloudOptions = """
         new-property: true
-        other-new-property: force""".stripIndent()
+        other-new-property: force
+      """.stripIndent()
     ```
 
 === "Kotlin"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1055,7 +1055,10 @@ Multiple options
 
 === "Groovy"
     ```groovy
-    additionalFlankOptions = "new-property: true\nother-new-property: force"
+    additionalFlankOptions = """
+      new-property: true
+      other-new-property: force
+    """.stripIndent()
     ```
 
 === "Kotlin"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1033,3 +1033,67 @@ fail-fast matrices and support is more limited because of that expectation.
     ```
     failFast.set(true)
     ```
+
+
+### additionalFlankConfig
+Allow appending additional config to flank root yaml. This option is useful when you would like to test option
+before it is available on Fladle. Supports both single and multiple properties.
+
+Single property
+
+=== "Groovy"
+```
+additionalFlankConfig = "new-property: true"
+```
+
+=== "Kotlin"
+```
+additionalFlankConfig.set("new-property: true")
+```
+
+Multiple properties
+
+=== "Groovy"
+```
+additionalFlankConfig = "new-property: true\nother-new-property: force"
+```
+
+=== "Kotlin"
+```
+additionalFlankConfig.set("""
+    new-property: true
+    other-new-property: force
+""".trimIndent())
+```
+
+### additionalGcloudConfig
+Allow appending additional config to gcloud root yaml. This option is useful when you would like to test option
+before it is available on Fladle. Supports both single and multiple properties.
+
+
+Single property
+
+=== "Groovy"
+```
+additionalGcloudConfig = "new-property: true"
+```
+
+=== "Kotlin"
+```
+additionalGcloudConfig.set("new-property: true")
+```
+
+Multiple properties
+
+=== "Groovy"
+```
+additionalGcloudConfig = "new-property: true\nother-new-property: force"
+```
+
+=== "Kotlin"
+```
+additionalGcloudConfig.set("""
+    new-property: true
+    other-new-property: force
+""".trimIndent())
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1037,7 +1037,7 @@ fail-fast matrices and support is more limited because of that expectation.
 
 ### additionalFlankOptions
 Appending additional option to flank root yaml. This option is useful when you would like to test options before official fladle support is added.
-before it is available on Fladle. Supports both single and multiple properties.
+Multiple options are supported.
 
 Single option
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1036,7 +1036,7 @@ fail-fast matrices and support is more limited because of that expectation.
 
 
 ### additionalFlankConfig
-Allow appending additional config to flank root yaml. This option is useful when you would like to test option
+Appending additional option to flank root yaml. This option is useful when you would like to test options before official fladle support is added.
 before it is available on Fladle. Supports both single and multiple properties.
 
 Single property

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FladleConfig.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FladleConfig.kt
@@ -425,7 +425,7 @@ interface FladleConfig {
    */
   @get:Input
   @get:Optional
-  val additionalFlankConfig: Property<String>
+  val additionalFlankOptions: Property<String>
 
   /**
    * Allow appending additional config to gcloud root yaml. This option is useful when you would like to test option
@@ -433,7 +433,7 @@ interface FladleConfig {
    */
   @get:Input
   @get:Optional
-  val additionalGcloudConfig: Property<String>
+  val additionalGcloudOptions: Property<String>
 
   @Internal
   fun getPresentProperties() = this::class.memberProperties

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FladleConfig.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FladleConfig.kt
@@ -419,6 +419,22 @@ interface FladleConfig {
   @get:Optional
   val failFast: Property<Boolean>
 
+  /**
+   * Allow appending additional config to flank root yaml. This option is useful when you would like to test option
+   * before it is available on Fladle. Supports both single and multiple properties.
+   */
+  @get:Input
+  @get:Optional
+  val additionalFlankConfig: Property<String>
+
+  /**
+   * Allow appending additional config to gcloud root yaml. This option is useful when you would like to test option
+   * before it is available on Fladle. Supports both single and multiple properties.
+   */
+  @get:Input
+  @get:Optional
+  val additionalGcloudConfig: Property<String>
+
   @Internal
   fun getPresentProperties() = this::class.memberProperties
     .filter {

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FladleConfigImpl.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FladleConfigImpl.kt
@@ -62,8 +62,8 @@ data class FladleConfigImpl(
   override val obbNames: ListProperty<String>,
   override val failFast: Property<Boolean>,
   override val maxTestShards: Property<Int>,
-  override val additionalFlankConfig: Property<String>,
-  override val additionalGcloudConfig: Property<String>
+  override val additionalFlankOptions: Property<String>,
+  override val additionalGcloudOptions: Property<String>
 ) : FladleConfig {
   /**
    * Prepare config to run sanity robo.

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FladleConfigImpl.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FladleConfigImpl.kt
@@ -61,7 +61,9 @@ data class FladleConfigImpl(
   override val obbFiles: ListProperty<String>,
   override val obbNames: ListProperty<String>,
   override val failFast: Property<Boolean>,
-  override val maxTestShards: Property<Int>
+  override val maxTestShards: Property<Int>,
+  override val additionalFlankConfig: Property<String>,
+  override val additionalGcloudConfig: Property<String>
 ) : FladleConfig {
   /**
    * Prepare config to run sanity robo.

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
@@ -136,9 +136,9 @@ open class FlankGradleExtension @Inject constructor(objects: ObjectFactory) : Fl
 
   override val maxTestShards: Property<Int> = objects.property()
 
-  override val additionalFlankConfig: Property<String> = objects.property()
+  override val additionalFlankOptions: Property<String> = objects.property()
 
-  override val additionalGcloudConfig: Property<String> = objects.property()
+  override val additionalGcloudOptions: Property<String> = objects.property()
 
   @Internal
   val configs: NamedDomainObjectContainer<FladleConfigImpl> = objects.domainObjectContainer(FladleConfigImpl::class.java) {
@@ -199,8 +199,8 @@ open class FlankGradleExtension @Inject constructor(objects: ObjectFactory) : Fl
       obbNames = objects.listProperty<String>().convention(obbNames),
       failFast = objects.property<Boolean>().convention(failFast),
       maxTestShards = objects.property<Int>().convention(maxTestShards),
-      additionalFlankConfig = objects.property<String>().convention(additionalFlankConfig),
-      additionalGcloudConfig = objects.property<String>().convention(additionalGcloudConfig)
+      additionalFlankOptions = objects.property<String>().convention(additionalFlankOptions),
+      additionalGcloudOptions = objects.property<String>().convention(additionalGcloudOptions)
     )
   }
 

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
@@ -136,6 +136,10 @@ open class FlankGradleExtension @Inject constructor(objects: ObjectFactory) : Fl
 
   override val maxTestShards: Property<Int> = objects.property()
 
+  override val additionalFlankConfig: Property<String> = objects.property()
+
+  override val additionalGcloudConfig: Property<String> = objects.property()
+
   @Internal
   val configs: NamedDomainObjectContainer<FladleConfigImpl> = objects.domainObjectContainer(FladleConfigImpl::class.java) {
     FladleConfigImpl(
@@ -194,7 +198,9 @@ open class FlankGradleExtension @Inject constructor(objects: ObjectFactory) : Fl
       obbFiles = objects.listProperty<String>().convention(obbFiles),
       obbNames = objects.listProperty<String>().convention(obbNames),
       failFast = objects.property<Boolean>().convention(failFast),
-      maxTestShards = objects.property<Int>().convention(maxTestShards)
+      maxTestShards = objects.property<Int>().convention(maxTestShards),
+      additionalFlankConfig = objects.property<String>().convention(additionalFlankConfig),
+      additionalGcloudConfig = objects.property<String>().convention(additionalGcloudConfig)
     )
   }
 

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/YamlWriter.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/YamlWriter.kt
@@ -112,6 +112,7 @@ internal class YamlWriter {
     appendListProperty(config.obbFiles, name = "obb-files") { appendln("    - $it") }
     appendListProperty(config.obbNames, name = "obb-names") { appendln("    - $it") }
     appendListProperty(config.testTargetsForShard, name = "test-targets-for-shard") { appendln("    - $it") }
+    appendProperty(config.failFast, name = "fail-fast")
     appendAdditionalProperty(config.additionalGcloudConfig)
   }
 

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/YamlWriter.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/YamlWriter.kt
@@ -74,6 +74,7 @@ internal class YamlWriter {
     appendListProperty(config.testTargetsForShard, name = "test-targets-for-shard") {
       appendln("    - $it")
     }
+    appendAdditionalProperty(config.additionalFlankConfig)
   }
 
   internal fun writeAdditionalProperties(config: FladleConfig): String = buildString {
@@ -111,7 +112,7 @@ internal class YamlWriter {
     appendListProperty(config.obbFiles, name = "obb-files") { appendln("    - $it") }
     appendListProperty(config.obbNames, name = "obb-names") { appendln("    - $it") }
     appendListProperty(config.testTargetsForShard, name = "test-targets-for-shard") { appendln("    - $it") }
-    appendProperty(config.failFast, name = "fail-fast")
+    appendAdditionalProperty(config.additionalGcloudConfig)
   }
 
   private fun <T> StringBuilder.appendProperty(prop: Property<T>, name: String) {
@@ -139,6 +140,18 @@ internal class YamlWriter {
       prop.get().forEach { custom(it) }
     }
   }
+
+  private fun StringBuilder.appendAdditionalProperty(property: Property<String>) {
+    if (property.isPresent) {
+      property.get()
+        .normalizeLineEnding()
+        .split("\n")
+        .map { "  $it" }
+        .forEach { appendln(it) }
+    }
+  }
+
+  private fun String.normalizeLineEnding() = replace("\r\n", "\n")
 
   private val <T> ListProperty<T>.isPresentAndNotEmpty
     get() = isPresent && get().isNotEmpty()

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/YamlWriter.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/YamlWriter.kt
@@ -74,7 +74,7 @@ internal class YamlWriter {
     appendListProperty(config.testTargetsForShard, name = "test-targets-for-shard") {
       appendln("    - $it")
     }
-    appendAdditionalProperty(config.additionalFlankConfig)
+    appendAdditionalProperty(config.additionalFlankOptions)
   }
 
   internal fun writeAdditionalProperties(config: FladleConfig): String = buildString {
@@ -113,7 +113,7 @@ internal class YamlWriter {
     appendListProperty(config.obbNames, name = "obb-names") { appendln("    - $it") }
     appendListProperty(config.testTargetsForShard, name = "test-targets-for-shard") { appendln("    - $it") }
     appendProperty(config.failFast, name = "fail-fast")
-    appendAdditionalProperty(config.additionalGcloudConfig)
+    appendAdditionalProperty(config.additionalGcloudOptions)
   }
 
   private fun <T> StringBuilder.appendProperty(prop: Property<T>, name: String) {

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/YamlWriter.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/YamlWriter.kt
@@ -145,14 +145,11 @@ internal class YamlWriter {
   private fun StringBuilder.appendAdditionalProperty(property: Property<String>) {
     if (property.isPresent) {
       property.get()
-        .normalizeLineEnding()
         .split("\n")
         .map { "  $it" }
         .forEach { appendln(it) }
     }
   }
-
-  private fun String.normalizeLineEnding() = replace("\r\n", "\n")
 
   private val <T> ListProperty<T>.isPresentAndNotEmpty
     get() = isPresent && get().isNotEmpty()

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/YamlWriterTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/YamlWriterTest.kt
@@ -1310,6 +1310,44 @@ class YamlWriterTest {
     assertThat(properties).contains("max-test-shards: 8")
   }
 
+  @Test
+  fun writeSingleLineAdditionalFlankProperty() {
+    val properties = emptyExtension {
+      additionalFlankConfig.set("new_version_property: test")
+    }.toFlankProperties()
+
+    assertThat(properties).contains("  new_version_property: test")
+  }
+
+  @Test
+  fun writeSingleLineAdditionalGcloudProperty() {
+    val properties = emptyExtension {
+      additionalGcloudConfig.set("new_version_property: test")
+    }.toAdditionalProperties()
+
+    assertThat(properties).contains("  new_version_property: test")
+  }
+
+  @Test
+  fun writeMultiLineAdditionalFlankProperies() {
+    val properties = emptyExtension {
+      additionalFlankConfig.set("new_version_property: test\nnew_version_property2: test2")
+    }.toFlankProperties()
+
+    assertThat(properties).contains("  new_version_property: test")
+    assertThat(properties).contains("  new_version_property2: test2")
+  }
+
+  @Test
+  fun writeMultiLineAdditionalGcloudProperties() {
+    val properties = emptyExtension {
+      additionalGcloudConfig.set("new_version_property: test\nnew_version_property2: test2")
+    }.toAdditionalProperties()
+
+    assertThat(properties).contains("  new_version_property: test")
+    assertThat(properties).contains("  new_version_property2: test2")
+  }
+
   private fun emptyExtension() = FlankGradleExtension(project.objects)
   private fun emptyExtension(block: FlankGradleExtension.() -> Unit) = emptyExtension().apply(block)
   private fun FlankGradleExtension.toFlankProperties() = yamlWriter.writeFlankProperties(this).trimIndent()

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/YamlWriterTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/YamlWriterTest.kt
@@ -1313,7 +1313,7 @@ class YamlWriterTest {
   @Test
   fun writeSingleLineAdditionalFlankProperty() {
     val properties = emptyExtension {
-      additionalFlankConfig.set("new_version_property: test")
+      additionalFlankOptions.set("new_version_property: test")
     }.toFlankProperties()
 
     assertThat(properties).contains("  new_version_property: test")
@@ -1322,7 +1322,7 @@ class YamlWriterTest {
   @Test
   fun writeSingleLineAdditionalGcloudProperty() {
     val properties = emptyExtension {
-      additionalGcloudConfig.set("new_version_property: test")
+      additionalGcloudOptions.set("new_version_property: test")
     }.toAdditionalProperties()
 
     assertThat(properties).contains("  new_version_property: test")
@@ -1331,7 +1331,7 @@ class YamlWriterTest {
   @Test
   fun writeMultiLineAdditionalFlankProperies() {
     val properties = emptyExtension {
-      additionalFlankConfig.set("new_version_property: test\nnew_version_property2: test2")
+      additionalFlankOptions.set("new_version_property: test\nnew_version_property2: test2")
     }.toFlankProperties()
 
     assertThat(properties).contains("  new_version_property: test")
@@ -1341,7 +1341,7 @@ class YamlWriterTest {
   @Test
   fun writeMultiLineAdditionalGcloudProperties() {
     val properties = emptyExtension {
-      additionalGcloudConfig.set("new_version_property: test\nnew_version_property2: test2")
+      additionalGcloudOptions.set("new_version_property: test\nnew_version_property2: test2")
     }.toAdditionalProperties()
 
     assertThat(properties).contains("  new_version_property: test")


### PR DESCRIPTION
Fixes #146 

Added 2 new options (`additionalFlankConfig` and `additionalGcloudConfig`) for support appending not supported option by Fladle to yaml file