### PR TITLE
Automatically assemble app + tests on runFlank

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -151,6 +151,7 @@ fladle {
       "class com.foo.ClassForShard3; package com.package.for.shard3"
     ]
     failFast = true
+    dependOnAssemble = true
 }
 ```
 
@@ -1102,4 +1103,16 @@ Multiple options
         new-property: true
         other-new-property: force
     """.trimIndent())
+    ```
+
+### dependOnAssemble
+If true, automatically builds app and test APKs before `runFlank` executes.
+
+=== "Groovy"
+    ``` groovy
+    dependOnAssemble = false
+    ```
+=== "Kotlin"
+    ``` kotlin
+    dependOnAssemble.set(false)
     ```

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,15 +1,9 @@
 # FAQ
 
 ## Error APK file not found
-The app APK and the instrumentation APK are expected to have already been generated before calling runFlank.
-If you would like the flank task to automatically create the APKs, you can add the following to your application's build.gradle.
-```
-afterEvaluate {
-    tasks.named("execFlank").configure {
-        dependsOn("assembleDebugAndroidTest")
-    }
-}
-```
+The app APK and the instrumentation APK are expected to have already been generated before calling runFlank. To generate APKs, run `assembleDebug` and `assembleDebugAndroidTest` before running `runFlank`. 
+You can also have Fladle build them for you by using the `dependsOnAssemble` property.
+
 
 See [https://issuetracker.google.com/issues/152240037]() for more information.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,10 +2,10 @@
 
 ## Error APK file not found
 The app APK and the instrumentation APK are expected to have already been generated before calling runFlank. To generate APKs, run `assembleDebug` and `assembleDebugAndroidTest` before running `runFlank`. 
-You can also have Fladle build them for you by using the `dependsOnAssemble` property.
+
+You can also have Fladle build them for you by using the [`dependOnAssemble`](../configuration/#dependOnAssemble) property.
 
 
-See [https://issuetracker.google.com/issues/152240037]() for more information.
 
 
 ## No signature of method

--- a/fladle-plugin/build.gradle.kts
+++ b/fladle-plugin/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 group = "com.osacky.flank.gradle"
-version = "0.14.2-SNAPSHOT"
+version = "0.15.0-SNAPSHOT"
 description = "Easily Scale your Android Instrumentation Tests with Firebase Test Lab with Flank"
 
 repositories {

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FladleConfig.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FladleConfig.kt
@@ -428,6 +428,14 @@ interface FladleConfig {
   val additionalFlankOptions: Property<String>
 
   /**
+   * Boolean to allow assembling application and test code automatically
+   * before flank runs
+   */
+  @get:Input
+  @get:Optional
+  val dependOnAssemble: Property<Boolean>
+
+  /**
    * Allow appending additional config to gcloud root yaml. This option is useful when you would like to test option
    * before it is available on Fladle. Supports both single and multiple properties.
    */

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FladleConfigImpl.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FladleConfigImpl.kt
@@ -63,7 +63,8 @@ data class FladleConfigImpl(
   override val failFast: Property<Boolean>,
   override val maxTestShards: Property<Int>,
   override val additionalFlankOptions: Property<String>,
-  override val additionalGcloudOptions: Property<String>
+  override val additionalGcloudOptions: Property<String>,
+  override val dependOnAssemble: Property<Boolean>
 ) : FladleConfig {
   /**
    * Prepare config to run sanity robo.

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FladlePluginDelegate.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FladlePluginDelegate.kt
@@ -1,6 +1,7 @@
 package com.osacky.flank.gradle
 
 import com.android.build.gradle.AppExtension
+import com.android.build.gradle.TestedExtension
 import com.android.build.gradle.internal.TaskManager.ASSEMBLE_ANDROID_TEST
 import com.android.builder.model.TestOptions
 import com.osacky.flank.gradle.validation.checkForExclusionUsage

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FladlePluginDelegate.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FladlePluginDelegate.kt
@@ -109,13 +109,16 @@ class FladlePluginDelegate {
       }
       dependsOn(writeConfigProps)
       if (config.dependOnAssemble.isPresent && config.dependOnAssemble.get()) {
-        val testedExtension = project.extensions.findByType(TestedExtension::class.java)
-        testedExtension?.testVariants?.configureEach {
-          if (testedVariant.assembleProvider.isPresent) {
-            dependsOn(testedVariant.assembleProvider.get())
+        project.extensions.findByType(TestedExtension::class.java)?.let { testedExtension ->
+          testedExtension.testVariants.configureEach {
+            if (testedVariant.assembleProvider.isPresent) {
+              dependsOn(testedVariant.assembleProvider.get())
+            }
+            if (assembleProvider.isPresent) {
+              dependsOn(assembleProvider.get())
+            }
           }
         }
-        dependsOn(ASSEMBLE_ANDROID_TEST)
       }
     }
 

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FladlePluginDelegate.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FladlePluginDelegate.kt
@@ -108,8 +108,13 @@ class FladlePluginDelegate {
       }
       dependsOn(writeConfigProps)
       if (config.dependOnAssemble.isPresent && config.dependOnAssemble.get()) {
+        val testedExtension = project.extensions.findByType(TestedExtension::class.java)
+        testedExtension?.testVariants?.configureEach {
+          if (testedVariant.assembleProvider.isPresent) {
+            dependsOn(testedVariant.assembleProvider.get())
+          }
+        }
         dependsOn(ASSEMBLE_ANDROID_TEST)
-        dependsOn("assemble")
       }
     }
 

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FladlePluginDelegate.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FladlePluginDelegate.kt
@@ -2,7 +2,6 @@ package com.osacky.flank.gradle
 
 import com.android.build.gradle.AppExtension
 import com.android.build.gradle.TestedExtension
-import com.android.build.gradle.internal.TaskManager.ASSEMBLE_ANDROID_TEST
 import com.android.builder.model.TestOptions
 import com.osacky.flank.gradle.validation.checkForExclusionUsage
 import com.osacky.flank.gradle.validation.validateOptionsUsed

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FladlePluginDelegate.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FladlePluginDelegate.kt
@@ -1,6 +1,7 @@
 package com.osacky.flank.gradle
 
 import com.android.build.gradle.AppExtension
+import com.android.build.gradle.internal.TaskManager.ASSEMBLE_ANDROID_TEST
 import com.android.builder.model.TestOptions
 import com.osacky.flank.gradle.validation.checkForExclusionUsage
 import com.osacky.flank.gradle.validation.validateOptionsUsed
@@ -106,6 +107,10 @@ class FladlePluginDelegate {
         environment(mapOf("GOOGLE_APPLICATION_CREDENTIALS" to config.serviceAccountCredentials.get()))
       }
       dependsOn(writeConfigProps)
+      if (config.dependOnAssemble.isPresent && config.dependOnAssemble.get()) {
+        dependsOn(ASSEMBLE_ANDROID_TEST)
+        dependsOn("assemble")
+      }
     }
 
     register("runFlank$name", RunFlankTask::class.java).configure {

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
@@ -29,7 +29,7 @@ open class FlankGradleExtension @Inject constructor(objects: ObjectFactory) : Fl
   override val useOrchestrator: Property<Boolean> = objects.property<Boolean>().convention(false)
   override val autoGoogleLogin: Property<Boolean> = objects.property<Boolean>().convention(false)
   override val devices: ListProperty<Map<String, String>> = objects.listProperty<Map<String, String>>().convention(listOf(mapOf("model" to "NexusLowRes", "version" to "28")))
-  override val dependOnAssemble: Property<Boolean> = objects.property<Boolean>().convention(false)
+
   // https://cloud.google.com/sdk/gcloud/reference/firebase/test/android/run
   override val testTargets: ListProperty<String> = objects.listProperty()
 
@@ -139,6 +139,8 @@ open class FlankGradleExtension @Inject constructor(objects: ObjectFactory) : Fl
   override val additionalFlankOptions: Property<String> = objects.property()
 
   override val additionalGcloudOptions: Property<String> = objects.property()
+
+  override val dependOnAssemble: Property<Boolean> = objects.property<Boolean>().convention(false)
 
   @Internal
   val configs: NamedDomainObjectContainer<FladleConfigImpl> = objects.domainObjectContainer(FladleConfigImpl::class.java) {

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
@@ -29,7 +29,7 @@ open class FlankGradleExtension @Inject constructor(objects: ObjectFactory) : Fl
   override val useOrchestrator: Property<Boolean> = objects.property<Boolean>().convention(false)
   override val autoGoogleLogin: Property<Boolean> = objects.property<Boolean>().convention(false)
   override val devices: ListProperty<Map<String, String>> = objects.listProperty<Map<String, String>>().convention(listOf(mapOf("model" to "NexusLowRes", "version" to "28")))
-
+  override val dependOnAssemble: Property<Boolean> = objects.property<Boolean>().convention(false)
   // https://cloud.google.com/sdk/gcloud/reference/firebase/test/android/run
   override val testTargets: ListProperty<String> = objects.listProperty()
 
@@ -200,7 +200,8 @@ open class FlankGradleExtension @Inject constructor(objects: ObjectFactory) : Fl
       failFast = objects.property<Boolean>().convention(failFast),
       maxTestShards = objects.property<Int>().convention(maxTestShards),
       additionalFlankOptions = objects.property<String>().convention(additionalFlankOptions),
-      additionalGcloudOptions = objects.property<String>().convention(additionalGcloudOptions)
+      additionalGcloudOptions = objects.property<String>().convention(additionalGcloudOptions),
+      dependOnAssemble = objects.property<Boolean>().convention(dependOnAssemble)
     )
   }
 

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FlankGradlePluginIntegrationTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FlankGradlePluginIntegrationTest.kt
@@ -169,26 +169,24 @@ class FlankGradlePluginIntegrationTest {
     val result = GradleRunner.create()
       .withProjectDir(testProjectRoot.root)
       .withPluginClasspath()
-      .withArguments("runFlank")
-      .buildAndFail()
-    // if this assertion fails, make sure you don't have a ~/.flank dir
-    assertThat(result.output).contains("Error: Failed to read service account credential.")
+      .withArguments("runFlank", "--dry-run")
+      .build()
+
     return result
   }
 
   @Test
   fun testWithDependOnAssemble() {
     val result = setUpDependOnAssemble(true)
-    assertThat(result.task(":assembleDebug")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
-    assertThat(result.task(":assembleDebugAndroidTest")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    assertThat(result.output).contains(":assembleDebug")
+    assertThat(result.output).contains(":assembleDebugAndroidTest")
   }
 
   @Test
   fun testWithOutDependOnAssemble() {
     val result = setUpDependOnAssemble(false)
-    result.tasks.filter { it.path.startsWith(":assembleDebug") }.map { it.path }.let { tasks ->
-      assertThat(tasks).isEmpty()
-    }
+    assertThat(result.output).doesNotContain(":assembleDebug")
+    assertThat(result.output).doesNotContain(":assembleDebugAndroidTest")
   }
 
   @Test

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FlankGradlePluginIntegrationTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FlankGradlePluginIntegrationTest.kt
@@ -1,6 +1,7 @@
 package com.osacky.flank.gradle.integration
 
 import com.google.common.truth.Truth.assertThat
+import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.Test
@@ -124,6 +125,69 @@ class FlankGradlePluginIntegrationTest {
       .withArguments("runFlank")
       .buildAndFail()
     assertThat(result.output).contains("debugApk must be specified")
+  }
+
+  fun setUpDependOnAssemble(dependsOnAssemble: Boolean): BuildResult  {
+      writeBuildGradle(
+          """plugins {
+          id "com.osacky.fladle"
+          id "com.android.application"
+         }
+         repositories {
+              google()
+              mavenCentral()
+          }
+         android {
+             compileSdkVersion 29
+             defaultConfig {
+                 applicationId "com.osacky.flank.gradle.sample"
+                 minSdkVersion 23
+                 targetSdkVersion 29
+                 versionCode 1
+                 versionName "1.0"
+                 testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+             }
+             testOptions {
+                 execution 'ANDROIDX_TEST_ORCHESTRATOR'
+              }
+         }
+         fladle {
+           serviceAccountCredentials = project.layout.projectDirectory.file("foo")
+           dependOnAssemble = $dependsOnAssemble
+         }
+    """.trimIndent()
+      )
+      testProjectRoot.newFile("foo").writeText("{}")
+      testProjectRoot.newFolder("src/main")
+      testProjectRoot.newFile("src/main/AndroidManifest.xml").writeText("""
+          <?xml version="1.0" encoding="utf-8"?>
+          <manifest package="com.osacky.flank.gradle.sample" xmlns:android="http://schemas.android.com/apk/res/android" />
+      """.trimIndent())
+      return GradleRunner.create()
+          .withProjectDir(testProjectRoot.root)
+          .withPluginClasspath()
+          .withGradleVersion("6.1.1")
+          .withArguments("runFlank")
+          .buildAndFail()
+  }
+
+  @Test
+  fun testWithDependOnAssemble() {
+      val result =  setUpDependOnAssemble(true)
+      result.tasks.filter { it.path.startsWith(":assembleDebug") }.map { it.path }.let { tasks ->
+          assertThat(tasks).isNotEmpty()
+          assertThat(tasks).contains(":assembleDebug")
+          assertThat(tasks).contains(":assembleDebugAndroidTest")
+      }
+
+  }
+
+  @Test
+  fun testWithOutDependOnAssemble() {
+    val result =  setUpDependOnAssemble(false)
+    result.tasks.filter { it.path.startsWith(":assembleDebug") }.map { it.path }.let { tasks ->
+      assertThat(tasks).isEmpty()
+    }
   }
 
   @Test

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FlankGradlePluginIntegrationTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FlankGradlePluginIntegrationTest.kt
@@ -128,9 +128,9 @@ class FlankGradlePluginIntegrationTest {
     assertThat(result.output).contains("debugApk must be specified")
   }
 
-  fun setUpDependOnAssemble(dependsOnAssemble: Boolean): BuildResult  {
+  private fun setUpDependOnAssemble(dependsOnAssemble: Boolean): BuildResult {
     writeBuildGradle(
-          """plugins {
+      """plugins {
           id "com.osacky.fladle"
           id "com.android.application"
          }
@@ -156,24 +156,26 @@ class FlankGradlePluginIntegrationTest {
            serviceAccountCredentials = project.layout.projectDirectory.file("foo")
            dependOnAssemble = $dependsOnAssemble
          }
-    """.trimIndent()
+      """.trimIndent()
     )
     testProjectRoot.newFile("foo").writeText("{}")
     testProjectRoot.newFolder("src/main")
-    testProjectRoot.newFile("src/main/AndroidManifest.xml").writeText("""
+    testProjectRoot.newFile("src/main/AndroidManifest.xml").writeText(
+      """
         <?xml version="1.0" encoding="utf-8"?>
         <manifest package="com.osacky.flank.gradle.sample" xmlns:android="http://schemas.android.com/apk/res/android" />
-      """.trimIndent())
+      """.trimIndent()
+    )
     return GradleRunner.create()
-        .withProjectDir(testProjectRoot.root)
-        .withPluginClasspath()
-        .withArguments("runFlank")
-        .buildAndFail()
+      .withProjectDir(testProjectRoot.root)
+      .withPluginClasspath()
+      .withArguments("runFlank")
+      .buildAndFail()
   }
 
   @Test
   fun testWithDependOnAssemble() {
-    val result =  setUpDependOnAssemble(true)
+    val result = setUpDependOnAssemble(true)
     assertThat(result.output).contains("There are no tests to run.")
     assertThat(result.task(":assembleDebug")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
     assertThat(result.task(":assembleDebugAndroidTest")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
@@ -181,7 +183,7 @@ class FlankGradlePluginIntegrationTest {
 
   @Test
   fun testWithOutDependOnAssemble() {
-    val result =  setUpDependOnAssemble(false)
+    val result = setUpDependOnAssemble(false)
     assertThat(result.output).contains("-debug.apk' from app doesn't exist")
     result.tasks.filter { it.path.startsWith(":assembleDebug") }.map { it.path }.let { tasks ->
       assertThat(tasks).isEmpty()

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FlankGradlePluginIntegrationTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FlankGradlePluginIntegrationTest.kt
@@ -176,7 +176,7 @@ class FlankGradlePluginIntegrationTest {
   @Test
   fun testWithDependOnAssemble() {
     val result = setUpDependOnAssemble(true)
-    assertThat(result.output).contains("PERMISSION_DENIED")
+    assertThat(result.output).contains("There are no tests to run.")
     assertThat(result.task(":assembleDebug")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
     assertThat(result.task(":assembleDebugAndroidTest")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
   }

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FlankGradlePluginIntegrationTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FlankGradlePluginIntegrationTest.kt
@@ -3,7 +3,6 @@ package com.osacky.flank.gradle.integration
 import com.google.common.truth.Truth.assertThat
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
-import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FlankGradlePluginIntegrationTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FlankGradlePluginIntegrationTest.kt
@@ -174,7 +174,8 @@ class FlankGradlePluginIntegrationTest {
   @Test
   fun testWithDependOnAssemble() {
       val result =  setUpDependOnAssemble(true)
-      result.tasks.filter { it.path.startsWith(":assembleDebug") }.map { it.path }.let { tasks ->
+        assertThat(result.task(":assembleDebug")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(result.task(":assembleDebugAndroidTest")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
           assertThat(tasks).isNotEmpty()
           assertThat(tasks).contains(":assembleDebug")
           assertThat(tasks).contains(":assembleDebugAndroidTest")

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FlankGradlePluginIntegrationTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FlankGradlePluginIntegrationTest.kt
@@ -155,7 +155,6 @@ class FlankGradlePluginIntegrationTest {
          fladle {
            serviceAccountCredentials = project.layout.projectDirectory.file("foo")
            dependOnAssemble = $dependsOnAssemble
-           projectId("flank-gradle")
          }
       """.trimIndent()
     )
@@ -177,7 +176,7 @@ class FlankGradlePluginIntegrationTest {
   @Test
   fun testWithDependOnAssemble() {
     val result = setUpDependOnAssemble(true)
-    assertThat(result.output).contains("There are no tests to run.")
+    assertThat(result.output).contains("PERMISSION_DENIED")
     assertThat(result.task(":assembleDebug")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
     assertThat(result.task(":assembleDebugAndroidTest")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
   }

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FlankGradlePluginIntegrationTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FlankGradlePluginIntegrationTest.kt
@@ -166,17 +166,19 @@ class FlankGradlePluginIntegrationTest {
         <manifest package="com.osacky.flank.gradle.sample" xmlns:android="http://schemas.android.com/apk/res/android" />
       """.trimIndent()
     )
-    return GradleRunner.create()
+    val result = GradleRunner.create()
       .withProjectDir(testProjectRoot.root)
       .withPluginClasspath()
       .withArguments("runFlank")
       .buildAndFail()
+    // if this assertion fails, make sure you don't have a ~/.flank dir
+    assertThat(result.output).contains("Error: Failed to read service account credential.")
+    return result
   }
 
   @Test
   fun testWithDependOnAssemble() {
     val result = setUpDependOnAssemble(true)
-    assertThat(result.output).contains("There are no tests to run.")
     assertThat(result.task(":assembleDebug")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
     assertThat(result.task(":assembleDebugAndroidTest")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
   }
@@ -184,7 +186,6 @@ class FlankGradlePluginIntegrationTest {
   @Test
   fun testWithOutDependOnAssemble() {
     val result = setUpDependOnAssemble(false)
-    assertThat(result.output).contains("-debug.apk' from app doesn't exist")
     result.tasks.filter { it.path.startsWith(":assembleDebug") }.map { it.path }.let { tasks ->
       assertThat(tasks).isEmpty()
     }

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FlankGradlePluginIntegrationTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FlankGradlePluginIntegrationTest.kt
@@ -167,7 +167,6 @@ class FlankGradlePluginIntegrationTest {
     return GradleRunner.create()
         .withProjectDir(testProjectRoot.root)
         .withPluginClasspath()
-        .withGradleVersion("6.1.1")
         .withArguments("runFlank")
         .buildAndFail()
   }

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FlankGradlePluginIntegrationTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FlankGradlePluginIntegrationTest.kt
@@ -155,6 +155,7 @@ class FlankGradlePluginIntegrationTest {
          fladle {
            serviceAccountCredentials = project.layout.projectDirectory.file("foo")
            dependOnAssemble = $dependsOnAssemble
+           projectId("flank-gradle")
          }
       """.trimIndent()
     )

--- a/sample-flavors-kotlin/build.gradle.kts
+++ b/sample-flavors-kotlin/build.gradle.kts
@@ -68,6 +68,7 @@ fladle {
         }
     }
     flakyTestAttempts.set(1)
+    dependOnAssemble.set(true)
 }
 
 dependencies {


### PR DESCRIPTION
This PR adds a new property, `dependOnAssemble`, in the `fladle` extension. This boolean can be used to turn on automatic building of app + test apk on `execFlank` and `runFlank`.

This is useful because now fladle can execute as soon as a project's APKs are available. As opposed to running `./gradlew assemble assembleAndroidTest` and then running fladle, where we would have to wait for _all_ APKs to be built before we can run fladle.