### PR TITLE
Allow Flank Snapshot Usage

### DIFF
--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
@@ -16,13 +16,19 @@ import org.gradle.kotlin.dsl.property
 import javax.inject.Inject
 
 open class FlankGradleExtension @Inject constructor(objects: ObjectFactory) : FladleConfig {
+
+  companion object {
+    const val FLANK_VERSION = "21.03.1"
+    const val FLANK_SNAPSHOT_VERSION = "flank-snapshot"
+  }
+
   @get:Input
   val flankCoordinates: Property<String> = objects.property(String::class.java).convention("com.github.flank:flank")
 
   override val sanityRobo: Property<Boolean> = objects.property<Boolean>().convention(false)
 
   @get:Input
-  val flankVersion: Property<String> = objects.property(String::class.java).convention("21.03.1")
+  val flankVersion: Property<String> = objects.property(String::class.java).convention(FLANK_VERSION)
   // Project id is automatically discovered by default. Use this to override the project id.
   override val projectId: Property<String> = objects.property()
   override val serviceAccountCredentials: RegularFileProperty = objects.fileProperty()

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/validation/ValidateOptions.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/validation/ValidateOptions.kt
@@ -1,16 +1,21 @@
 package com.osacky.flank.gradle.validation
 
 import com.osacky.flank.gradle.FladleConfig
+import com.osacky.flank.gradle.FlankGradleExtension.Companion.FLANK_SNAPSHOT_VERSION
+import com.osacky.flank.gradle.FlankGradleExtension.Companion.FLANK_VERSION
 import org.gradle.util.VersionNumber
 import kotlin.reflect.full.memberProperties
 
-fun validateOptionsUsed(config: FladleConfig, flank: String) = config
-  .getPresentProperties()
-  .mapNotNull { property -> properties[property.name]?.let { property to it } }
-  .forEach { (property, version) ->
-    val configFlankVersion = flank.toVersion()
-    if (version > configFlankVersion) throw IllegalStateException("Option ${property.name} is available since flank $version, which is higher than used $configFlankVersion")
-  }
+fun validateOptionsUsed(config: FladleConfig, flank: String) {
+  // if using snapshot version default to the latest known version of flank for validation checks
+  val configFlankVersion = if (flank == FLANK_SNAPSHOT_VERSION) FLANK_VERSION.toVersion() else flank.toVersion()
+
+  config.getPresentProperties()
+    .mapNotNull { property -> properties[property.name]?.let { property to it } }
+    .forEach { (property, version) ->
+      if (version > configFlankVersion) throw IllegalStateException("Option ${property.name} is available since flank $version, which is higher than used $configFlankVersion")
+    }
+}
 
 private fun String.toVersion() = VersionNumber.parse(this)
 

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/ConfigurationCacheTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/ConfigurationCacheTest.kt
@@ -108,12 +108,12 @@ class ConfigurationCacheTest {
     testProjectRoot.newFile("flank-gradle-service-account.json").writeText("{ \"project_id\": \"foo\" }")
     val result = configCachingRunner("runFlank").buildAndFail()
 
-    assertThat(result.output).contains("Error: Failed to read service account credential.")
+    assertThat(result.output).contains("Flank encountered a 403 error when running on project foo")
     assertThat(result.output).contains("Configuration cache entry stored.")
 
     val secondResult = configCachingRunner("runFlank").buildAndFail()
 
-    assertThat(secondResult.output).contains("Error: Failed to read service account credential.")
+    assertThat(secondResult.output).contains("Flank encountered a 403 error when running on project foo")
     assertThat(secondResult.output).contains("Reusing configuration cache.")
   }
 

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/ConfigurationCacheTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/ConfigurationCacheTest.kt
@@ -108,12 +108,12 @@ class ConfigurationCacheTest {
     testProjectRoot.newFile("flank-gradle-service-account.json").writeText("{ \"project_id\": \"foo\" }")
     val result = configCachingRunner("runFlank").buildAndFail()
 
-    assertThat(result.output).contains("Flank encountered a 403 error when running on project foo")
+    assertThat(result.output).contains("Error: Failed to read service account credential.")
     assertThat(result.output).contains("Configuration cache entry stored.")
 
     val secondResult = configCachingRunner("runFlank").buildAndFail()
 
-    assertThat(secondResult.output).contains("Flank encountered a 403 error when running on project foo")
+    assertThat(secondResult.output).contains("Error: Failed to read service account credential.")
     assertThat(secondResult.output).contains("Reusing configuration cache.")
   }
 


### PR DESCRIPTION
Validation checks were causing certain configurations to fail because
the snapshot version would become `0.0.0`. This defaults
the snapshot version checks to use the default version of flank.