### PR TITLE
Simple change in docs for clarification

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -10,7 +10,7 @@ Credentials are stored in `~/.flank`.
 
 1. `./gradlew flankAuth`
 2. Sign in to web browser.
-3. Specify [projectId](../configuration/#projectid)
+3. Specify [projectId](../configuration/#projectid) in fladle configuration
 4. `./gradlew runFlank`
 
 ## Service account credentials


### PR DESCRIPTION
Although it has a proper link, the project id part looks like it is related to the above step about web authentication. 2 of our team members had this same confusion. That's why I thought this would make it more clear.