### PR TITLE
Allow not adding certain modules to additionalTestApks.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.4.32'
+    ext.kotlin_version = '1.5.0'
     repositories {
         google()
         mavenCentral()
@@ -43,7 +43,7 @@ buildScan {
 }
 
 tasks.wrapper.configure {
-    gradleVersion = '7.0'
+    gradleVersion = '7.0.2'
 }
 
 def isNonStable = { String version ->

--- a/fladle-plugin/build.gradle.kts
+++ b/fladle-plugin/build.gradle.kts
@@ -163,7 +163,7 @@ tasks.withType(ValidatePlugins::class.java).configureEach {
   enableStricterValidation.set(true)
 }
 
-// Ensure Java 8 Compatibilty. See https://github.com/runningcode/fladle/issues/246
+// Ensure Java 8 Compatibility. See https://github.com/runningcode/fladle/issues/246
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class.java).configureEach {
   kotlinOptions.jvmTarget = "1.8"
 }

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FulladleModuleExtension.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FulladleModuleExtension.kt
@@ -1,0 +1,16 @@
+package com.osacky.flank.gradle
+
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.kotlin.dsl.property
+import javax.inject.Inject
+
+open class FulladleModuleExtension @Inject constructor(objects: ObjectFactory) {
+
+  /**
+   * When set to false, Fulladle will not automatically add this module to additionalTestApks.
+   *
+   * Default: true
+   */
+  val enabled: Property<Boolean> = objects.property<Boolean>().convention(true)
+}

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/AutoConfigureFladleTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/AutoConfigureFladleTest.kt
@@ -37,9 +37,6 @@ class AutoConfigureFladleTest {
     )
 
     testProjectRoot.setupFixture(fixtureName)
-    testProjectRoot.root.walk().forEach {
-      println(it)
-    }
 
     val result = GradleRunner.create()
       .withProjectDir(testProjectRoot.root)

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FulladlePluginIntegrationTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FulladlePluginIntegrationTest.kt
@@ -1,10 +1,10 @@
 package com.osacky.flank.gradle.integration
 
 import com.google.common.truth.Truth.assertThat
-import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import java.io.File
 
 class FulladlePluginIntegrationTest {
   @get:Rule
@@ -22,11 +22,104 @@ class FulladlePluginIntegrationTest {
              |  id "com.osacky.fulladle"
              |}""".trimMargin()
     )
-    val result = GradleRunner.create()
-      .withProjectDir(testProjectRoot.root)
-      .withPluginClasspath()
+    val result = testProjectRoot.gradleRunner()
+      .withArguments("help")
       .withGradleVersion("6.0")
       .build()
     assertThat(result.output).contains("SUCCESS")
+  }
+
+  @Test
+  fun fulladleWithSubmodules() {
+    val appFixture = "android-project"
+    val libraryFixture = "android-library-project"
+    val ignoredLibraryProject = "android-lib-ignored"
+    testProjectRoot.newFile("settings.gradle").writeText(
+      """
+        include '$appFixture'
+        include '$libraryFixture'
+        include '$ignoredLibraryProject'
+        
+        dependencyResolutionManagement {
+          repositories {
+            mavenCentral()
+            google()
+          }
+        }
+      """.trimIndent()
+    )
+    testProjectRoot.setupFixture(appFixture)
+    testProjectRoot.setupFixture(libraryFixture)
+    File(testProjectRoot.root, libraryFixture).copyRecursively(testProjectRoot.newFile(ignoredLibraryProject), overwrite = true)
+
+    writeBuildGradle(
+      """
+        buildscript {
+            repositories {
+                google()
+                jcenter()
+            }
+
+            dependencies {
+                classpath 'com.android.tools.build:gradle:4.2.1'
+            }
+        }
+        
+        plugins {
+          id "com.osacky.fulladle"
+        }
+        
+        
+        fladle {
+          serviceAccountCredentials = project.layout.projectDirectory.file("android-project/flank-gradle-5cf02dc90531.json")
+        }
+      """.trimIndent()
+    )
+
+    // Configure second included project to ignore fulladle module
+    File(testProjectRoot.root, "$ignoredLibraryProject/build.gradle").appendText(
+      """
+      fulladleModuleConfig {
+        enabled = false
+      }
+      """.trimIndent()
+    )
+
+    val result = testProjectRoot.gradleRunner()
+      .withArguments(":printYml")
+      .withGradleVersion("6.9")
+      .build()
+
+    assertThat(result.output).contains("SUCCESS")
+    // Ensure that there is only one additional test APK even though there are two library modules.
+    assertThat(result.output).containsMatch(
+      """
+     > Task :printYml
+     gcloud:
+       app: [0-9a-zA-Z\/_]*/android-project/build/outputs/apk/debug/android-project-debug.apk
+       test: [0-9a-zA-Z\/_]*/android-project/build/outputs/apk/androidTest/debug/android-project-debug-androidTest.apk
+       device:
+       - model: NexusLowRes
+         version: 28
+     
+       use-orchestrator: false
+       auto-google-login: false
+       record-video: true
+       performance-metrics: true
+       timeout: 15m
+       num-flaky-test-attempts: 0
+     
+     flank:
+       keep-file-path: false
+       additional-app-test-apks:
+         - test: [0-9a-zA-Z\/_]*/android-library-project/build/outputs/apk/androidTest/debug/android-library-project-debug-androidTest.apk
+       ignore-failed-tests: false
+       disable-sharding: false
+       smart-flank-disable-upload: false
+       legacy-junit-result: false
+       full-junit-result: false
+       output-style: single
+      """.trimIndent()
+    )
   }
 }

--- a/fladle-plugin/src/test/resources/android-library-project/build.gradle
+++ b/fladle-plugin/src/test/resources/android-library-project/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+    id 'com.android.library'
+}
+
+android {
+    compileSdkVersion 29
+    defaultConfig {
+        targetSdkVersion 29
+        versionCode 1
+        versionName "1.0"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+    testOptions {
+        execution 'ANDROIDX_TEST_ORCHESTRATOR'
+    }
+}
+
+dependencies {
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation("androidx.navigation:navigation-fragment-ktx:2.3.0")
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.1'
+    testImplementation 'junit:junit:4.13'
+    androidTestImplementation 'androidx.test:rules:1.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+}
+

--- a/fladle-plugin/src/test/resources/android-library-project/src/androidTest/java/com/osacky/flank/gradle/sample/ExampleInstrumentedTest.java
+++ b/fladle-plugin/src/test/resources/android-library-project/src/androidTest/java/com/osacky/flank/gradle/sample/ExampleInstrumentedTest.java
@@ -1,0 +1,33 @@
+package com.osacky.flank.gradle.sample;
+
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.action.ViewActions.typeText;
+import java.lang.RuntimeException;
+
+@RunWith(AndroidJUnit4.class)
+public class ExampleInstrumentedTest {
+
+  @Rule
+  private final ActivityTestRule testRule = new ActivityTestRule(MainActivity.class);
+
+  @Test
+  public void seeView() {
+    onView(withId(R.id.text_view_hello)).check(matches(isDisplayed()));
+  }
+
+  @Test
+  public void runAndFail() {
+    throw new RuntimeException("Test failed");
+  }
+}

--- a/fladle-plugin/src/test/resources/android-library-project/src/main/AndroidManifest.xml
+++ b/fladle-plugin/src/test/resources/android-library-project/src/main/AndroidManifest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="com.osacky.flank.gradle.sample"
+          xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application
+        android:label="@string/app_name"
+    >
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/fladle-plugin/src/test/resources/android-library-project/src/main/java/com/osacky/flank/gradle/sample/MainActivity.java
+++ b/fladle-plugin/src/test/resources/android-library-project/src/main/java/com/osacky/flank/gradle/sample/MainActivity.java
@@ -1,0 +1,13 @@
+package com.osacky.flank.gradle.sample;
+
+import androidx.appcompat.app.AppCompatActivity;
+import android.os.Bundle;
+
+public class MainActivity extends AppCompatActivity {
+
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
+  }
+}

--- a/fladle-plugin/src/test/resources/android-library-project/src/main/res/layout/activity_main.xml
+++ b/fladle-plugin/src/test/resources/android-library-project/src/main/res/layout/activity_main.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".MainActivity">
+
+    <TextView
+        android:id="@+id/text_view_hello"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Hello World!"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/fladle-plugin/src/test/resources/android-library-project/src/main/res/values/strings.xml
+++ b/fladle-plugin/src/test/resources/android-library-project/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Flank Gradle Plugin Sample</string>
+</resources>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/sample-android-library/build.gradle.kts
+++ b/sample-android-library/build.gradle.kts
@@ -3,6 +3,10 @@ plugins {
   kotlin("android")
 }
 
+fulladleModuleConfig {
+  enabled.set(false)
+}
+
 android {
   compileSdkVersion(29)
   defaultConfig {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.gradle.enterprise" version "3.5.1"
+  id "com.gradle.enterprise" version "3.6.1"
 }
 
 include ':android-library-no-tests'


### PR DESCRIPTION
Modules can now be omitted with
```
fulladleModuleConfig {
  enabled = false
}
```

fixes #202

TODO:
- [ ] Update docs
- [ ] Maybe use `exclude` instead of `enabled`?
