### PR TITLE
Small log improvement

### DIFF
--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FulladlePlugin.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FulladlePlugin.kt
@@ -117,7 +117,7 @@ class FulladlePlugin : Plugin<Project> {
                     )
                   }
                 } else {
-                  println("ignoring variant for $this in $projectDir")
+                  println("Ignoring $name test variant in $path: No tests in $projectDir/src/androidTest")
                 }
               }
             }


### PR DESCRIPTION
Improved log message for when a module has no tests. The current message gives no information about why the variant is ignored.

Current message:
`ignoring variant for com.android.build.gradle.internal.api.TestVariantImpl_Decorated@6fb9b464 in /xyz/ftl/fladle/android-library-no-tests`

New message:
`Ignoring debugAndroidTest test variant in :android-library-no-tests: No tests in /xyz/fladle/android-library-no-tests/src/androidTest`