### PR TITLE
Removed hardcoded flank snapshot version

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -224,11 +224,11 @@ Need a different Flank version? Specify it with `flankVersion`.
 To use a snapshot:
 === "Groovy"
     ``` groovy
-    flankVersion = "flank-snapshot"`
+    flankVersion = "flank_snapshot"`
     ```
 === "Kotlin"
     ``` kotlin
-    flankVersion.set("flank-snapshot")
+    flankVersion.set("flank_snapshot")
     ```
 
 Need more than 50 shards? Use Flank `8.1.0`.

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
@@ -18,7 +18,7 @@ open class FlankGradleExtension @Inject constructor(objects: ObjectFactory) : Fl
 
   companion object {
     const val FLANK_VERSION = "21.06.0"
-    const val FLANK_SNAPSHOT_VERSION = "flank-snapshot"
+    const val FLANK_SNAPSHOT_VERSION = "flank_snapshot"
   }
 
   @get:Input

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
@@ -18,7 +18,6 @@ open class FlankGradleExtension @Inject constructor(objects: ObjectFactory) : Fl
 
   companion object {
     const val FLANK_VERSION = "21.06.0"
-    const val FLANK_SNAPSHOT_VERSION = "flank_snapshot"
   }
 
   @get:Input

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/validation/ValidateOptions.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/validation/ValidateOptions.kt
@@ -1,14 +1,13 @@
 package com.osacky.flank.gradle.validation
 
 import com.osacky.flank.gradle.FladleConfig
-import com.osacky.flank.gradle.FlankGradleExtension.Companion.FLANK_SNAPSHOT_VERSION
 import com.osacky.flank.gradle.FlankGradleExtension.Companion.FLANK_VERSION
 import org.gradle.util.VersionNumber
 import kotlin.reflect.full.memberProperties
 
 fun validateOptionsUsed(config: FladleConfig, flank: String) {
   // if using snapshot version default to the latest known version of flank for validation checks
-  val configFlankVersion = if (flank == FLANK_SNAPSHOT_VERSION) FLANK_VERSION.toVersion() else flank.toVersion()
+  val configFlankVersion = if (flank.toLowerCase().endsWith("snapshot")) FLANK_VERSION.toVersion() else flank.toVersion()
 
   config.getPresentProperties()
     .mapNotNull { property -> properties[property.name]?.let { property to it } }


### PR DESCRIPTION
Flank's snapshot release is called [flank_snapshot](https://mvnrepository.com/artifact/com.github.flank/flank/flank_snapshot), instead of hardcoding this inside fladle (which had hardcoded an older version), we can just check if the version ends with the string "snapshot" (case-insensitive).
