### PR TITLE
Added fulladleModuleConfig to app modules

### DIFF
--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FulladlePlugin.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FulladlePlugin.kt
@@ -127,6 +127,7 @@ fun configureApplicationModule(project: Project, flankGradleExtension: FlankGrad
           }
           val maxTestShards = fulladleModuleExtension.maxTestShards.let {
             buildString {
+              if (it.isPresent) { append("    ") }
               appendProperty(it, name = "max-test-shards")
             }
           }.trimEnd()

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FulladlePlugin.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FulladlePlugin.kt
@@ -94,6 +94,8 @@ fun configureLibraryModule(project: Project, flankGradleExtension: FlankGradleEx
 fun configureApplicationModule(project: Project, flankGradleExtension: FlankGradleExtension) = project.run {
   pluginManager.withPlugin("com.android.application") {
     val fulladleModuleExtension = extensions.getByType(FulladleModuleExtension::class.java)
+    if (!fulladleModuleExtension.enabled.get())
+      return@withPlugin
     val appExtension = extensions.getByType<AppExtension>()
     // Only configure the first test variant per module.
     // Does anyone test more than one variant per module?

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FulladlePlugin.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FulladlePlugin.kt
@@ -121,7 +121,6 @@ fun configureApplicationModule(project: Project, flankGradleExtension: FlankGrad
           // If the instrumentation apk isn't yet set, let's use this one.
           if (!flankGradleExtension.instrumentationApk.isPresent) {
             flankGradleExtension.instrumentationApk.set(rootProject.provider { this@test.outputFile.absolutePath })
-
           } else {
             // Otherwise, let's just add it to the list.
             strs.add("      test: ${this@test.outputFile}")

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FulladlePluginIntegrationTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FulladlePluginIntegrationTest.kt
@@ -126,11 +126,13 @@ class FulladlePluginIntegrationTest {
   @Test
   fun fulladleWithSubmoduleOverrides() {
     val appFixture = "android-project"
+    val appFixture2 = "android-project2"
     val libraryFixture = "android-library-project"
     val libraryFixture2 = "android-lib2"
     testProjectRoot.newFile("settings.gradle").writeText(
       """
         include '$appFixture'
+        include '$appFixture2'
         include '$libraryFixture'
         include '$libraryFixture2'
 
@@ -143,6 +145,7 @@ class FulladlePluginIntegrationTest {
       """.trimIndent()
     )
     testProjectRoot.setupFixture(appFixture)
+    testProjectRoot.setupFixture(appFixture2)
     testProjectRoot.setupFixture(libraryFixture)
     File(testProjectRoot.root, libraryFixture).copyRecursively(testProjectRoot.newFile(libraryFixture2), overwrite = true)
 
@@ -222,6 +225,11 @@ class FulladlePluginIntegrationTest {
          - test: [0-9a-zA-Z\/_]*/$libraryFixture/build/outputs/apk/androidTest/debug/android-library-project-debug-androidTest.apk
            app: dummy_app.apk
            max-test-shards: 7
+           environment-variables:
+               "clearPackageData": "true"
+         - app: [0-9a-zA-Z\/_]*/android-project2/build/outputs/apk/debug/android-project2-debug.apk
+           test: [0-9a-zA-Z\/_]*/android-project2/build/outputs/apk/androidTest/debug/android-project2-debug-androidTest.apk
+           max-test-shards: 5
            environment-variables:
                "clearPackageData": "true"
        ignore-failed-tests: false

--- a/fladle-plugin/src/test/resources/android-project2/build.gradle
+++ b/fladle-plugin/src/test/resources/android-project2/build.gradle
@@ -1,0 +1,59 @@
+plugins {
+    id 'com.android.application'
+    id 'com.osacky.fladle'
+}
+
+android {
+    compileSdkVersion 29
+    defaultConfig {
+        applicationId "com.osacky.flank.gradle.sample"
+        minSdkVersion 23
+        targetSdkVersion 29
+        versionCode 1
+        versionName "1.0"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+    testOptions {
+        execution 'ANDROIDX_TEST_ORCHESTRATOR'
+    }
+}
+
+fladle {
+    serviceAccountCredentials = project.layout.projectDirectory.file("flank-gradle-5cf02dc90531.json")
+    useOrchestrator = true
+    environmentVariables = [
+            "clearPackageData": "true"
+    ]
+    testTargets = [
+            "class com.osacky.flank.gradle.sample.ExampleInstrumentedTest#seeView"
+    ]
+    devices = [
+            [ "model": "Pixel2", "version": "26" ],
+            [ "model": "Nexus5", "version": "23" ]
+    ]
+    smartFlankGcsPath = "gs://test-lab-yr9w6qsdvy45q-iurp80dm95h8a/flank/test_app_android.xml"
+    configs {
+        oranges {
+            useOrchestrator.set(false)
+            testTargets.set(project.provider { [
+                    "class com.osacky.flank.gradle.sample.ExampleInstrumentedTest#runAndFail"
+            ] })
+            flakyTestAttempts.set(3)
+        }
+    }
+}
+
+fulladleModuleConfig {
+    maxTestShards = 5
+    environmentVariables = ["clearPackageData": "true"]
+}
+dependencies {
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation("androidx.navigation:navigation-fragment-ktx:2.3.0")
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.1'
+    testImplementation 'junit:junit:4.13'
+    androidTestImplementation 'androidx.test:rules:1.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+}
+

--- a/fladle-plugin/src/test/resources/android-project2/src/androidTest/java/com/osacky/flank/gradle/sample/ExampleInstrumentedTest.java
+++ b/fladle-plugin/src/test/resources/android-project2/src/androidTest/java/com/osacky/flank/gradle/sample/ExampleInstrumentedTest.java
@@ -1,0 +1,33 @@
+package com.osacky.flank.gradle.sample;
+
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.action.ViewActions.typeText;
+import java.lang.RuntimeException;
+
+@RunWith(AndroidJUnit4.class)
+public class ExampleInstrumentedTest {
+
+  @Rule
+  private final ActivityTestRule testRule = new ActivityTestRule(MainActivity.class);
+
+  @Test
+  public void seeView() {
+    onView(withId(R.id.text_view_hello)).check(matches(isDisplayed()));
+  }
+
+  @Test
+  public void runAndFail() {
+    throw new RuntimeException("Test failed");
+  }
+}

--- a/fladle-plugin/src/test/resources/android-project2/src/main/AndroidManifest.xml
+++ b/fladle-plugin/src/test/resources/android-project2/src/main/AndroidManifest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="com.osacky.flank.gradle.sample"
+          xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application
+        android:label="@string/app_name"
+    >
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/fladle-plugin/src/test/resources/android-project2/src/main/java/com/osacky/flank/gradle/sample/MainActivity.java
+++ b/fladle-plugin/src/test/resources/android-project2/src/main/java/com/osacky/flank/gradle/sample/MainActivity.java
@@ -1,0 +1,13 @@
+package com.osacky.flank.gradle.sample;
+
+import androidx.appcompat.app.AppCompatActivity;
+import android.os.Bundle;
+
+public class MainActivity extends AppCompatActivity {
+
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
+  }
+}

--- a/fladle-plugin/src/test/resources/android-project2/src/main/res/layout/activity_main.xml
+++ b/fladle-plugin/src/test/resources/android-project2/src/main/res/layout/activity_main.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".MainActivity">
+
+    <TextView
+        android:id="@+id/text_view_hello"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Hello World!"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/fladle-plugin/src/test/resources/android-project2/src/main/res/values/strings.xml
+++ b/fladle-plugin/src/test/resources/android-project2/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Flank Gradle Plugin Sample</string>
+</resources>

--- a/sample-flavors-kotlin/build.gradle.kts
+++ b/sample-flavors-kotlin/build.gradle.kts
@@ -71,6 +71,20 @@ fladle {
     dependOnAssemble.set(true)
 }
 
+fulladleModuleConfig {
+    maxTestShards.set(24)
+    clientDetails.set(
+        mapOf(
+            "key1" to "val1"
+        )
+    )
+    environmentVariables.set(
+        mapOf(
+            "clearPackageData" to "true"
+        )
+    )
+}
+
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7")
     implementation("androidx.appcompat:appcompat:1.1.0")


### PR DESCRIPTION
A previous PR (#257 ) added the ability to override library module's configuration. This PR extends that ability to app modules as well.

This PR also breaks down the configuration of app and library modules in FulladlePlugin into their own separate methods for better readability. 