### PR TITLE
Treat app and library modules the same in Fulladle

### DIFF
--- a/android-library-no-tests/build.gradle.kts
+++ b/android-library-no-tests/build.gradle.kts
@@ -12,6 +12,10 @@ android {
   }
 }
 
+fulladleModuleConfig {
+  debugApk.set(rootProject.file("dummy_app.apk").path)
+}
+
 dependencies {
   implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7")
   implementation("androidx.appcompat:appcompat:1.1.0")

--- a/docs/multi-module-testing.md
+++ b/docs/multi-module-testing.md
@@ -103,6 +103,15 @@ You may want to exclude a library module from testing when using Fulladle. You c
       enabled.set(false)
     }
     ```
+
+
+### Overriding root-level config
+Flank offers two different ways to specify APKs for testing, one is the *root-level* configuration (under the `gcloud` namespace) and the other is as an `additional-app-test-apks` (under the `flank` namespace).
+
+Fulladle does not provide the ability to control which module ends up as the root-level module or as an additional module. Either one of app modules or library modules can become a root-level module. If a library module ends up as a root-level module, it needs to specify a `debugApk` in its `fladle` or `fulladleModuleConfig` block.
+
+The root-level configuration (e.g. `maxTestShards`) can also be overridden in the `fulladleModuleConfig` block of whatever module gets picked as the root module.
+
 ## Troubleshooting
 Fulladle might still have some rough edges, but we'd love feedback. Please join us in the [Firebase Community Slack](https://firebase.community/) with any feedback you may have.
 You can also file [Fladle Github issues](https://github.com/runningcode/fladle/issues).

--- a/docs/multi-module-testing.md
+++ b/docs/multi-module-testing.md
@@ -106,8 +106,6 @@ You may want to exclude a library module from testing when using Fulladle. You c
 
 
 ### Overriding root-level config
-Flank offers two different ways to specify APKs for testing, one is the *root-level* configuration (under the `gcloud` namespace) and the other is as an `additional-app-test-apks` (under the `flank` namespace).
-
 Fulladle does not provide the ability to control which module ends up as the root-level module or as an additional module. Either one of app modules or library modules can become a root-level module. If a library module ends up as a root-level module, it needs to specify a `debugApk` in its `fladle` or `fulladleModuleConfig` block.
 
 The root-level configuration (e.g. `maxTestShards`) can also be overridden in the `fulladleModuleConfig` block of whatever module gets picked as the root module.

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
@@ -17,7 +17,7 @@ import javax.inject.Inject
 open class FlankGradleExtension @Inject constructor(objects: ObjectFactory) : FladleConfig {
 
   companion object {
-    const val FLANK_VERSION = "21.06.0"
+    const val FLANK_VERSION = "21.07.1"
   }
 
   @get:Input

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FulladlePlugin.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FulladlePlugin.kt
@@ -23,7 +23,7 @@ class FulladlePlugin : Plugin<Project> {
     }
 
     val fulladleConfigureTask = root.tasks.register("configureFulladle") {
-      var allModulesDisabled = true
+      var modulesEnabled = false
       /**
        * we will first configure all app modules
        * then configure all library modules
@@ -41,7 +41,7 @@ class FulladlePlugin : Plugin<Project> {
         root.subprojects {
           if (!hasAndroidTest)
             return@subprojects
-          allModulesDisabled = false
+          modulesEnabled = true
           if (isAndroidAppModule)
             configureModule(this, flankGradleExtension)
         }
@@ -49,12 +49,14 @@ class FulladlePlugin : Plugin<Project> {
         root.subprojects {
           if (!hasAndroidTest)
             return@subprojects
-          allModulesDisabled = false
+          modulesEnabled = true
           if (isAndroidLibraryModule)
             configureModule(this, flankGradleExtension)
         }
-        check(!allModulesDisabled) {
-          "All modules were disabled for testing in fulladleModuleConfig or the enabled modules had no tests"
+
+        check(modulesEnabled) {
+          "All modules were disabled for testing in fulladleModuleConfig or the enabled modules had no tests.\n" +
+                  "Either re-enable modules for testing or add modules with tests."
         }
       }
     }
@@ -222,5 +224,3 @@ fun overrideRootLevelConfigs(flankGradleExtension: FlankGradleExtension, fulladl
     flankGradleExtension.environmentVariables.set(fulladleModuleExtension.environmentVariables.get())
   }
 }
-
-fun setUpRootDebugApk() {}

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FulladlePlugin.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FulladlePlugin.kt
@@ -56,7 +56,7 @@ class FulladlePlugin : Plugin<Project> {
 
         check(modulesEnabled) {
           "All modules were disabled for testing in fulladleModuleConfig or the enabled modules had no tests.\n" +
-                  "Either re-enable modules for testing or add modules with tests."
+            "Either re-enable modules for testing or add modules with tests."
         }
       }
     }

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FulladlePlugin.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FulladlePlugin.kt
@@ -214,9 +214,6 @@ fun overrideRootLevelConfigs(flankGradleExtension: FlankGradleExtension, fulladl
   if (fulladleModuleExtension.maxTestShards.orNull != null) {
     flankGradleExtension.maxTestShards.set(fulladleModuleExtension.maxTestShards.get())
   }
-  if (fulladleModuleExtension.maxTestShards.orNull != null) {
-    flankGradleExtension.maxTestShards.set(fulladleModuleExtension.maxTestShards.get())
-  }
   if (fulladleModuleExtension.clientDetails.orNull != null) {
     flankGradleExtension.clientDetails.set(fulladleModuleExtension.clientDetails.get())
   }

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FulladlePlugin.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FulladlePlugin.kt
@@ -25,7 +25,7 @@ class FulladlePlugin : Plugin<Project> {
     val fulladleConfigureTask = root.tasks.register("configureFulladle") {
       doLast {
         root.subprojects {
-          configureModule(this,flankGradleExtension)
+          configureModule(this, flankGradleExtension)
         }
       }
     }
@@ -83,8 +83,8 @@ fun configureModule(project: Project, flankGradleExtension: FlankGradleExtension
           }
         } else {
           // Otherwise, let's just add it to the list.
-          if (project.isAndroidAppModule){
-              strs.add("- app: ${this@app.outputFile}")
+          if (project.isAndroidAppModule) {
+            strs.add("- app: ${this@app.outputFile}")
           } else if (project.isAndroidLibraryModule) {
             strs.add("- app: ${fulladleModuleExtension.debugApk.get()}")
           }
@@ -118,7 +118,6 @@ fun configureModule(project: Project, flankGradleExtension: FlankGradleExtension
     }
   }
 }
-
 
 fun mapPropertyToYaml(map: MapProperty<String, String>, propName: String) =
   map.let {

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FulladlePlugin.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FulladlePlugin.kt
@@ -183,7 +183,6 @@ val Project.isAndroidAppModule
 val Project.isAndroidLibraryModule
   get() = plugins.hasPlugin("com.android.library")
 
-
 // returns false if the module explicitly disabled testing or if it simply had no tests
 val Project.hasAndroidTest: Boolean
   get() {

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FulladlePlugin.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FulladlePlugin.kt
@@ -92,7 +92,6 @@ fun configureModule(project: Project, flankGradleExtension: FlankGradleExtension
     testedVariant.outputs.configureEach app@{
       this@testVariant.outputs.configureEach test@{
         val strs = mutableListOf<String>()
-
         // If the debugApk isn't yet set, let's use this one.
         if (!flankGradleExtension.debugApk.isPresent) {
           if (project.isAndroidAppModule) {
@@ -129,15 +128,17 @@ fun configureModule(project: Project, flankGradleExtension: FlankGradleExtension
         if (strs.isEmpty()) {
           // this is the root module
           // should not be added as additional test apk
+          overrideRootLevelConfigs(flankGradleExtension, fulladleModuleExtension)
           return@test
         }
+        // the first element can be "app" or "test", whatever it is prepend - to it
+        strs[0] = "- ${strs[0].trim()}"
 
         val maxTestShards = propertyToYaml(fulladleModuleExtension.maxTestShards, "max-test-shards")
         val clientDetails = mapPropertyToYaml(fulladleModuleExtension.clientDetails, "client-details")
         val environmentVariables = mapPropertyToYaml(fulladleModuleExtension.environmentVariables, "environment-variables")
 
         strs.addAll(listOf(maxTestShards, clientDetails, environmentVariables))
-        strs[0] = "- ${strs[0].trim()}"
 
         writeAdditionalTestApps(strs, flankGradleExtension, rootProject)
 
@@ -202,3 +203,25 @@ val Project.hasAndroidTest: Boolean
     }
     return testsFound
   }
+
+fun overrideRootLevelConfigs(flankGradleExtension: FlankGradleExtension, fulladleModuleExtension: FulladleModuleExtension) {
+  // if the root module overrode any value in its fulladleModuleConfig block
+  // then use those values instead
+  if (fulladleModuleExtension.debugApk.orNull != null) {
+    flankGradleExtension.debugApk.set(fulladleModuleExtension.debugApk.get())
+  }
+  if (fulladleModuleExtension.maxTestShards.orNull != null) {
+    flankGradleExtension.maxTestShards.set(fulladleModuleExtension.maxTestShards.get())
+  }
+  if (fulladleModuleExtension.maxTestShards.orNull != null) {
+    flankGradleExtension.maxTestShards.set(fulladleModuleExtension.maxTestShards.get())
+  }
+  if (fulladleModuleExtension.clientDetails.orNull != null) {
+    flankGradleExtension.clientDetails.set(fulladleModuleExtension.clientDetails.get())
+  }
+  if (fulladleModuleExtension.environmentVariables.orNull != null) {
+    flankGradleExtension.environmentVariables.set(fulladleModuleExtension.environmentVariables.get())
+  }
+}
+
+fun setUpRootDebugApk() {}

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FulladlePlugin.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FulladlePlugin.kt
@@ -1,7 +1,5 @@
 package com.osacky.flank.gradle
 
-import com.android.build.gradle.AppExtension
-import com.android.build.gradle.LibraryExtension
 import com.android.build.gradle.TestedExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -74,6 +72,7 @@ fun configureModule(project: Project, flankGradleExtension: FlankGradleExtension
       this@testVariant.outputs.configureEach test@{
         val strs = mutableListOf<String>()
 
+        // If the debugApk isn't yet set, let's use this one.
         if (!flankGradleExtension.debugApk.isPresent) {
           if (project.isAndroidAppModule) {
             // app modules produce app apks that we can consume

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FulladlePluginIntegrationTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FulladlePluginIntegrationTest.kt
@@ -26,7 +26,6 @@ class FulladlePluginIntegrationTest {
     )
     val result = testProjectRoot.gradleRunner()
       .withArguments("help")
-      .withGradleVersion("6.0")
       .build()
     assertThat(result.output).contains("SUCCESS")
   }
@@ -89,7 +88,6 @@ class FulladlePluginIntegrationTest {
 
     val result = testProjectRoot.gradleRunner()
       .withArguments(":printYml")
-      .withGradleVersion("6.9")
       .build()
 
     assertThat(result.output).contains("SUCCESS")
@@ -195,7 +193,6 @@ class FulladlePluginIntegrationTest {
 
     val result = testProjectRoot.gradleRunner()
       .withArguments(":printYml")
-      .withGradleVersion("6.9")
       .build()
 
     assertThat(result.output).contains("SUCCESS")
@@ -296,7 +293,6 @@ class FulladlePluginIntegrationTest {
 
     val result = testProjectRoot.gradleRunner()
       .withArguments(":printYml")
-      .withGradleVersion("6.9")
       .build()
     assertThat(result.output).doesNotContain("max-test-shards: 4")
     assertThat(result.output).contains("max-test-shards: 7")
@@ -353,7 +349,6 @@ class FulladlePluginIntegrationTest {
 
     val result = testProjectRoot.gradleRunner()
       .withArguments(":printYml")
-      .withGradleVersion("6.9")
       .buildAndFail()
 
     assertThat(result.output).contains("Task :configureFulladle FAILED")
@@ -430,7 +425,6 @@ class FulladlePluginIntegrationTest {
 
     val result = testProjectRoot.gradleRunner()
       .withArguments(":printYml")
-      .withGradleVersion("6.9")
       .buildAndFail()
 
     assertThat(result.output).contains("Task :configureFulladle FAILED")
@@ -519,7 +513,6 @@ class FulladlePluginIntegrationTest {
 
     val result = testProjectRoot.gradleRunner()
       .withArguments(":printYml")
-      .withGradleVersion("6.9")
       .build()
 
     assertThat(result.output).doesNotContain("additional-app-test-apks")
@@ -604,7 +597,6 @@ class FulladlePluginIntegrationTest {
 
     val result = testProjectRoot.gradleRunner()
       .withArguments(":printYml")
-      .withGradleVersion("6.9")
       .build()
 
     assertThat(result.output).contains("BUILD SUCCESSFUL")

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FulladlePluginIntegrationTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FulladlePluginIntegrationTest.kt
@@ -468,7 +468,7 @@ class FulladlePluginIntegrationTest {
      gcloud:
        app: dummy_app.apk
        test: [0-9a-zA-Z\/_]*/$libraryFixture/build/outputs/apk/androidTest/debug/android-library-project-debug-androidTest.apk
-       """.trimIndent()
+      """.trimIndent()
     )
     assertThat(result.output).contains("SUCCESS")
   }

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FulladlePluginIntegrationTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FulladlePluginIntegrationTest.kt
@@ -217,19 +217,19 @@ class FulladlePluginIntegrationTest {
      flank:
        keep-file-path: false
        additional-app-test-apks:
+         - app: [0-9a-zA-Z\/_]*/android-project2/build/outputs/apk/debug/android-project2-debug.apk
+           test: [0-9a-zA-Z\/_]*/android-project2/build/outputs/apk/androidTest/debug/android-project2-debug-androidTest.apk
+           max-test-shards: 5
+           environment-variables:
+               "clearPackageData": "true"
          - test: [0-9a-zA-Z\/_]*/$libraryFixture2/build/outputs/apk/androidTest/debug/android-lib2-debug-androidTest.apk
            max-test-shards: 4
            client-details:
                "test-type": "PR"
                "build-number": "132"
-         - test: [0-9a-zA-Z\/_]*/$libraryFixture/build/outputs/apk/androidTest/debug/android-library-project-debug-androidTest.apk
-           app: dummy_app.apk
+         - app: dummy_app.apk
+           test: [0-9a-zA-Z\/_]*/$libraryFixture/build/outputs/apk/androidTest/debug/android-library-project-debug-androidTest.apk
            max-test-shards: 7
-           environment-variables:
-               "clearPackageData": "true"
-         - app: [0-9a-zA-Z\/_]*/android-project2/build/outputs/apk/debug/android-project2-debug.apk
-           test: [0-9a-zA-Z\/_]*/android-project2/build/outputs/apk/androidTest/debug/android-project2-debug-androidTest.apk
-           max-test-shards: 5
            environment-variables:
                "clearPackageData": "true"
        ignore-failed-tests: false

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FulladlePluginIntegrationTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FulladlePluginIntegrationTest.kt
@@ -10,7 +10,7 @@ class FulladlePluginIntegrationTest {
   @get:Rule
   var testProjectRoot = TemporaryFolder()
 
-    val agpDependency: String = "com.android.tools.build:gradle:4.2.1"
+  val agpDependency: String = "com.android.tools.build:gradle:4.2.1"
 
   fun writeBuildGradle(build: String) {
     val file = testProjectRoot.newFile("build.gradle")

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FulladlePluginIntegrationTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FulladlePluginIntegrationTest.kt
@@ -10,6 +10,8 @@ class FulladlePluginIntegrationTest {
   @get:Rule
   var testProjectRoot = TemporaryFolder()
 
+    val agpDependency: String = "com.android.tools.build:gradle:4.2.1"
+
   fun writeBuildGradle(build: String) {
     val file = testProjectRoot.newFile("build.gradle")
     file.writeText(build)
@@ -61,7 +63,7 @@ class FulladlePluginIntegrationTest {
             }
 
             dependencies {
-                classpath 'com.android.tools.build:gradle:4.2.1'
+                classpath '$agpDependency'
             }
         }
         
@@ -158,7 +160,7 @@ class FulladlePluginIntegrationTest {
             }
 
             dependencies {
-                classpath 'com.android.tools.build:gradle:4.2.1'
+                classpath '$agpDependency'
             }
         }
 
@@ -268,7 +270,7 @@ class FulladlePluginIntegrationTest {
             }
 
             dependencies {
-                classpath 'com.android.tools.build:gradle:4.2.1'
+                classpath '$agpDependency'
             }
         }
 
@@ -327,7 +329,7 @@ class FulladlePluginIntegrationTest {
             }
 
             dependencies {
-                classpath 'com.android.tools.build:gradle:4.2.1'
+                classpath '$agpDependency'
             }
         }
 
@@ -396,7 +398,7 @@ class FulladlePluginIntegrationTest {
             }
 
             dependencies {
-                classpath 'com.android.tools.build:gradle:4.2.1'
+                classpath '$agpDependency'
             }
         }
 
@@ -478,7 +480,7 @@ class FulladlePluginIntegrationTest {
             }
 
             dependencies {
-                classpath 'com.android.tools.build:gradle:4.2.1'
+                classpath '$agpDependency'
             }
         }
 
@@ -570,7 +572,7 @@ class FulladlePluginIntegrationTest {
             }
 
             dependencies {
-                classpath 'com.android.tools.build:gradle:4.2.1'
+                classpath '$agpDependency'
             }
         }
 

--- a/sample-android-library/build.gradle.kts
+++ b/sample-android-library/build.gradle.kts
@@ -14,6 +14,7 @@ fulladleModuleConfig {
   environmentVariables.set(mapOf(
     "clearPackageData" to "true"
   ))
+  debugApk.set(rootProject.file("dummy_app.apk").path)
 }
 
 android {

--- a/sample-android-library/build.gradle.kts
+++ b/sample-android-library/build.gradle.kts
@@ -14,7 +14,6 @@ fulladleModuleConfig {
   environmentVariables.set(mapOf(
     "clearPackageData" to "true"
   ))
-  debugApk.set(rootProject.file("dummy_app.apk").path)
 }
 
 android {

--- a/sample-android-library/build.gradle.kts
+++ b/sample-android-library/build.gradle.kts
@@ -10,7 +10,7 @@ fulladleModuleConfig {
     "build-number" to "132",
     "module-name" to project.path,
   ))
-  maxTestShards.set(3)
+  maxTestShards.set(13)
   environmentVariables.set(mapOf(
     "clearPackageData" to "true"
   ))

--- a/sample-flavors-kotlin/build.gradle.kts
+++ b/sample-flavors-kotlin/build.gradle.kts
@@ -83,6 +83,7 @@ fulladleModuleConfig {
             "clearPackageData" to "true"
         )
     )
+    debugApk.set("${rootProject.file("dummy_app.apk")}")
 }
 
 dependencies {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -75,6 +75,10 @@ fladle {
     flakyTestAttempts = 1
 }
 
+fulladleModuleConfig {
+    debugApk.set("${rootProject.file("dummy_app.apk")}")
+}
+
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.1.0'

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -76,7 +76,10 @@ fladle {
 }
 
 fulladleModuleConfig {
-    debugApk.set("${rootProject.file("dummy_app.apk")}")
+    clientDetails = [
+            "test-type": "PR",
+            "build-number": "132"
+    ]
 }
 
 dependencies {


### PR DESCRIPTION
This PR merges the methods used to configure app and library modules in Fulladle plugin.

One major problem it solves is handling library modules as root-level app/test APKs (in case there are no app modules, or all app modules are disabled).


Root-level flank app/test apks are both required, and since libraries don't produce app APKs, we first try to set app modules as root level APKs. If none of the app modules are enabled (or if they have no tests), we then try to set libraries as the root-level app. Libraries need to explicitly set `debugApk` in their `fulladleModuleConfig` block for the APK to be consumed.