### PR TITLE
Default fulladleModuleConfig maps to null

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,9 @@ allprojects {
 
 fladle {
     serviceAccountCredentials = project.layout.projectDirectory.file("sample/flank-gradle-5cf02dc90531.json")
+    environmentVariables = [
+        "var1-key" : "var1-value"
+    ]
 }
 
 buildScan {

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FulladleModuleExtension.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FulladleModuleExtension.kt
@@ -27,13 +27,13 @@ open class FulladleModuleExtension @Inject constructor(objects: ObjectFactory) {
    * When consuming the test results, such as in Cloud Functions or a CI system,
    * these details can add additional context such as a link to the corresponding pull request.
    */
-  val clientDetails: MapProperty<String, String> = objects.mapProperty()
+  val clientDetails: MapProperty<String, String> = objects.mapProperty(String::class.java, String::class.java).convention(null)
 
   /**
    * The environment variables are mirrored as extra options to the am instrument -e KEY1 VALUE1 … command and
    * passed to your test runner (typically AndroidJUnitRunner)
    */
-  val environmentVariables: MapProperty<String, String> = objects.mapProperty()
+  val environmentVariables: MapProperty<String, String> = objects.mapProperty(String::class.java, String::class.java).convention(null)
 
   /**
    * the app under test

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FulladlePluginIntegrationTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FulladlePluginIntegrationTest.kt
@@ -73,6 +73,12 @@ class FulladlePluginIntegrationTest {
         
         fladle {
           serviceAccountCredentials = project.layout.projectDirectory.file("android-project/flank-gradle-5cf02dc90531.json")
+          environmentVariables = [
+            "clearPackageData": "true"
+          ]
+          clientDetails = [
+            "key1" : "val1"
+          ]
         }
       """.trimIndent()
     )
@@ -107,7 +113,11 @@ class FulladlePluginIntegrationTest {
        record-video: true
        performance-metrics: true
        timeout: 15m
+       environment-variables:
+         clearPackageData: true
        num-flaky-test-attempts: 0
+       client-details:
+         key1: val1
      
      flank:
        keep-file-path: false


### PR DESCRIPTION
Initializing fulladleModuleConfig's maps to null so that we can check for null-ness (instead of emptiness) before using them.