### PR TITLE
Do not override root level configs with empty properties

### DIFF
--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FulladlePlugin.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FulladlePlugin.kt
@@ -210,16 +210,20 @@ val Project.hasAndroidTest: Boolean
 fun overrideRootLevelConfigs(flankGradleExtension: FlankGradleExtension, fulladleModuleExtension: FulladleModuleExtension) {
   // if the root module overrode any value in its fulladleModuleConfig block
   // then use those values instead
-  if (fulladleModuleExtension.debugApk.orNull != null) {
+  val debugApk = fulladleModuleExtension.debugApk.orNull
+  if (debugApk != null && debugApk.isNotEmpty()) {
     flankGradleExtension.debugApk.set(fulladleModuleExtension.debugApk.get())
   }
-  if (fulladleModuleExtension.maxTestShards.orNull != null) {
+  val maxTestShards = fulladleModuleExtension.maxTestShards.orNull
+  if (maxTestShards != null && maxTestShards > 0) {
     flankGradleExtension.maxTestShards.set(fulladleModuleExtension.maxTestShards.get())
   }
-  if (fulladleModuleExtension.clientDetails.orNull != null) {
+  val clientDetails = fulladleModuleExtension.clientDetails.orNull
+  if (clientDetails != null && clientDetails.size != 0) {
     flankGradleExtension.clientDetails.set(fulladleModuleExtension.clientDetails.get())
   }
-  if (fulladleModuleExtension.environmentVariables.orNull != null) {
+  val env = fulladleModuleExtension.environmentVariables.orNull
+  if (env != null && env.size != 0) {
     flankGradleExtension.environmentVariables.set(fulladleModuleExtension.environmentVariables.get())
   }
 }

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/AutoConfigureFladleTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/AutoConfigureFladleTest.kt
@@ -64,6 +64,7 @@ class AutoConfigureFladleTest {
           timeout: 15m
           environment-variables:
             clearPackageData: true
+            listener: com.osacky.flank.sample.Listener
           test-targets:
           - class com.osacky.flank.gradle.sample.ExampleInstrumentedTest#seeView
           num-flaky-test-attempts: 0

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FulladlePluginIntegrationTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FulladlePluginIntegrationTest.kt
@@ -238,6 +238,10 @@ class FulladlePluginIntegrationTest {
 
         fladle {
           serviceAccountCredentials = project.layout.projectDirectory.file("android-project/flank-gradle-5cf02dc90531.json")
+          environmentVariables = [
+            "clearPackageData": "true", 
+            "listener": "com.osacky.flank.sample.Listener"
+          ]
         }
       """.trimIndent()
     )
@@ -255,7 +259,10 @@ class FulladlePluginIntegrationTest {
       """
       fulladleModuleConfig {
         maxTestShards = 7
-        environmentVariables = ["clearPackageData": "true"]
+        environmentVariables = [
+            "clearPackageData": "false",
+            "listener": "com.osacky.flank.sample.Listener.Different"
+        ]
         debugApk = "dummy_app.apk"
       }
       """.trimIndent()
@@ -281,6 +288,9 @@ class FulladlePluginIntegrationTest {
        record-video: true
        performance-metrics: true
        timeout: 15m
+       environment-variables:
+         clearPackageData: true
+         listener: com.osacky.flank.sample.Listener
        num-flaky-test-attempts: 0
 
      flank:
@@ -290,7 +300,7 @@ class FulladlePluginIntegrationTest {
            test: [0-9a-zA-Z\/_]*/android-project2/build/outputs/apk/androidTest/debug/android-project2-debug-androidTest.apk
            max-test-shards: 5
            environment-variables:
-               "clearPackageData": "true"
+               "clearPackageData": "false"
          - test: [0-9a-zA-Z\/_]*/$libraryFixture2/build/outputs/apk/androidTest/debug/android-lib2-debug-androidTest.apk
            max-test-shards: 4
            client-details:
@@ -300,7 +310,8 @@ class FulladlePluginIntegrationTest {
            test: [0-9a-zA-Z\/_]*/$libraryFixture/build/outputs/apk/androidTest/debug/android-library-project-debug-androidTest.apk
            max-test-shards: 7
            environment-variables:
-               "clearPackageData": "true"
+               "clearPackageData": "false"
+               "listener": "com.osacky.flank.sample.Listener.Different"
        ignore-failed-tests: false
        disable-sharding: false
        smart-flank-disable-upload: false

--- a/fladle-plugin/src/test/resources/android-project/build.gradle
+++ b/fladle-plugin/src/test/resources/android-project/build.gradle
@@ -22,7 +22,8 @@ fladle {
     serviceAccountCredentials = project.layout.projectDirectory.file("flank-gradle-5cf02dc90531.json")
     useOrchestrator = true
     environmentVariables = [
-            "clearPackageData": "true"
+            "clearPackageData": "true",
+            "listener": "com.osacky.flank.sample.Listener"
     ]
     testTargets = [
             "class com.osacky.flank.gradle.sample.ExampleInstrumentedTest#seeView"

--- a/fladle-plugin/src/test/resources/android-project2/build.gradle
+++ b/fladle-plugin/src/test/resources/android-project2/build.gradle
@@ -45,7 +45,7 @@ fladle {
 
 fulladleModuleConfig {
     maxTestShards = 5
-    environmentVariables = ["clearPackageData": "true"]
+    environmentVariables = ["clearPackageData": "false"]
 }
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'


### PR DESCRIPTION
Fixes https://github.com/runningcode/fladle/issues/270

Documentation for using different environment variables per test apk 
https://flank.github.io/flank/using_different_environment_variables_in_different_matrices/

Disclamer; I didnt build local snapshot version and I didnt try final result. But I will.
