### PR TITLE
Support ABI splits

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+* Add `abi` option to support selecting a particular debug APK in projects that use [ABI splits](https://developer.android.com/studio/build/configure-apk-splits#configure-abi-split) to produce multiple APKs. [PR](https://github.com/runningcode/fladle/pull/281)
 
 ## 0.17.2
 * Fix configuration cache support.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -458,6 +458,21 @@ will be marked as "successful". The matrix with a flaky test will be marked as f
     ``` kotlin
     flakyTestAttempts.set(0)
     ```
+
+### abi
+The [ABI](https://developer.android.com/ndk/guides/abis.html#sa) split of the application that should be tested (e.g. "x86"). Only required if the application under test uses [ABI splits](https://developer.android.com/studio/build/configure-apk-splits#configure-abi-split) and the debug APK is selected automatically (via [variant](../configuration/#variant)) instead of manually (via [debugApk](../configuration/#debugapk)).
+
+If the application uses ABI splits, and this property isn't specified, an arbitrary ABI split will be selected.
+
+=== "Groovy"
+    ``` groovy
+    abi = "arm64-v8a"
+    ```
+=== "Kotlin"
+    ``` kotlin
+    abi.set("arm64-v8a")
+    ```
+
 ### directoriesToPull
 A list of paths that will be copied from the device's storage to the designated results bucket after the test is complete. These must be absolute paths under `/sdcard` or `/data/local/tmp`.  Path names are restricted to the characters `a-zA-Z0-9_-./+`. The paths `/sdcard` and `/data` will be made available and treated as implicit path substitutions. E.g. if `/sdcard` on a particular device does not map to external storage, the system will replace it with the external storage path prefix for that device.
 

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FladleConfig.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FladleConfig.kt
@@ -117,6 +117,19 @@ interface FladleConfig {
   @get:Optional
   val variant: Property<String>
 
+  /**
+   * ABI split to use for configuring output APK.
+   *
+   * If the application under test uses ABI splits, setting this property to a particular ABI value
+   * (e.g. "x86") will select the version of the APK to use. If the application uses ABI splits and
+   * no value is provided, an arbitrary APK will be selected.
+   *
+   * See [the Android docs for ABI splits](https://developer.android.com/studio/build/configure-apk-splits#configure-abi-split).
+   */
+  @get:Input
+  @get:Optional
+  val abi: Property<String>
+
   @get:Input
   @get:Optional
   val resultsBucket: Property<String>

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FladleConfigImpl.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FladleConfigImpl.kt
@@ -24,6 +24,7 @@ data class FladleConfigImpl(
   override val resultsHistoryName: Property<String>,
   override val flakyTestAttempts: Property<Int>,
   override val variant: Property<String>,
+  override val abi: Property<String>,
   override val directoriesToPull: ListProperty<String>,
   override val filesToDownload: ListProperty<String>,
   override val environmentVariables: MapProperty<String, String>,

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
@@ -50,6 +50,8 @@ open class FlankGradleExtension @Inject constructor(objects: ObjectFactory) : Fl
 
   override val variant: Property<String> = objects.property()
 
+  override val abi: Property<String> = objects.property()
+
   /**
    * debugApk and instrumentationApk are [Property<String>] and not [RegularFileProperty] because we support wildcard characters.
    */
@@ -165,6 +167,7 @@ open class FlankGradleExtension @Inject constructor(objects: ObjectFactory) : Fl
       resultsHistoryName = objects.property<String>().convention(resultsHistoryName),
       flakyTestAttempts = objects.property<Int>().convention(flakyTestAttempts),
       variant = objects.property<String>().convention(variant),
+      abi = objects.property<String>().convention(abi),
       directoriesToPull = objects.listProperty<String>().convention(directoriesToPull),
       filesToDownload = objects.listProperty<String>().convention(filesToDownload),
       environmentVariables = objects.mapProperty<String, String>().convention(environmentVariables),

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/Variants.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/Variants.kt
@@ -1,0 +1,25 @@
+package com.osacky.flank.gradle
+
+import com.android.build.VariantOutput
+import com.android.build.gradle.api.BaseVariant
+import com.android.build.gradle.api.BaseVariantOutput
+
+/**
+ * Returns true if this [BaseVariant] matches the variant specified in the [config].
+ *
+ * If no variant is specified, all variants are considered a match.
+ */
+fun BaseVariant.isExpectedVariant(config: FladleConfig) =
+  !config.variant.isPresent || (config.variant.isPresent && config.variant.get() == this.name)
+
+/**
+ * Returns true if this [BaseVariantOutput] matches the ABI specified in the [config].
+ *
+ * If the config does not specify an ABI, or if the config specifies an ABI but the [BaseVariantOutput]
+ * is not filtered by ABI, it is considered a match.
+ */
+fun BaseVariantOutput.isExpectedAbiOutput(config: FladleConfig): Boolean {
+  return !config.abi.isPresent ||
+    !filterTypes.contains(VariantOutput.FilterType.ABI.name) ||
+    filters.single { it.filterType == VariantOutput.FilterType.ABI.name }.identifier == config.abi.get()
+}

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FulladlePluginIntegrationTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FulladlePluginIntegrationTest.kt
@@ -58,7 +58,6 @@ class FulladlePluginIntegrationTest {
         buildscript {
             repositories {
                 google()
-                jcenter()
             }
 
             dependencies {
@@ -152,7 +151,6 @@ class FulladlePluginIntegrationTest {
         buildscript {
             repositories {
                 google()
-                jcenter()
             }
 
             dependencies {
@@ -225,7 +223,6 @@ class FulladlePluginIntegrationTest {
         buildscript {
             repositories {
                 google()
-                jcenter()
             }
 
             dependencies {
@@ -348,7 +345,6 @@ class FulladlePluginIntegrationTest {
         buildscript {
             repositories {
                 google()
-                jcenter()
             }
 
             dependencies {
@@ -406,7 +402,6 @@ class FulladlePluginIntegrationTest {
         buildscript {
             repositories {
                 google()
-                jcenter()
             }
 
             dependencies {
@@ -474,7 +469,6 @@ class FulladlePluginIntegrationTest {
         buildscript {
             repositories {
                 google()
-                jcenter()
             }
 
             dependencies {
@@ -555,7 +549,6 @@ class FulladlePluginIntegrationTest {
         buildscript {
             repositories {
                 google()
-                jcenter()
             }
 
             dependencies {
@@ -646,7 +639,6 @@ class FulladlePluginIntegrationTest {
         buildscript {
             repositories {
                 google()
-                jcenter()
             }
 
             dependencies {
@@ -718,7 +710,6 @@ class FulladlePluginIntegrationTest {
         buildscript {
             repositories {
                 google()
-                jcenter()
             }
             dependencies {
                 classpath '$agpDependency'

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FulladlePluginIntegrationTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FulladlePluginIntegrationTest.kt
@@ -686,4 +686,131 @@ class FulladlePluginIntegrationTest {
 
     assertThat(result.output).contains("BUILD SUCCESSFUL")
   }
+
+  @Test
+  fun fulladleWithAbiSplits() {
+    val appFixtureWithAbiSplits = "android-project-with-abi-splits"
+    val appFixture = "android-project"
+    val appFixtureTwo = "android-project2"
+    val libraryFixture = "android-library-project"
+    testProjectRoot.newFile("settings.gradle").writeText(
+      """
+        include '$appFixtureWithAbiSplits'
+        include '$appFixture'
+        include '$appFixtureTwo'
+        include '$libraryFixture'
+
+        dependencyResolutionManagement {
+          repositories {
+            mavenCentral()
+            google()
+          }
+        }
+      """.trimIndent()
+    )
+    testProjectRoot.setupFixture(appFixture)
+    testProjectRoot.setupFixture(appFixtureTwo)
+    testProjectRoot.setupFixture(libraryFixture)
+    File(testProjectRoot.root, appFixture).copyRecursively(testProjectRoot.newFile(appFixtureWithAbiSplits), overwrite = true)
+
+    writeBuildGradle(
+      """
+        buildscript {
+            repositories {
+                google()
+                jcenter()
+            }
+            dependencies {
+                classpath '$agpDependency'
+            }
+        }
+        plugins {
+          id "com.osacky.fulladle"
+        }
+        fladle {
+          serviceAccountCredentials = project.layout.projectDirectory.file("android-project/flank-gradle-5cf02dc90531.json")
+          abi = "armeabi-v7a"
+        }
+      """.trimIndent()
+    )
+
+    // Overwrite android-project fixture to include ABI splits.
+    File(testProjectRoot.root, "$appFixtureWithAbiSplits/build.gradle").writeText(
+      """
+      plugins {
+          id "com.android.application"
+      }
+      android {
+         compileSdkVersion 29
+         defaultConfig {
+             applicationId "com.osacky.flank.gradle.sample"
+             minSdkVersion 23
+             targetSdkVersion 29
+             versionCode 1
+             versionName "1.0"
+             testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+         }
+         testOptions {
+             execution 'ANDROIDX_TEST_ORCHESTRATOR'
+         }
+         splits {
+             abi {
+                enable true
+                reset()
+                include "x86", "armeabi-v7a", "arm64-v8a", "x86_64"
+                universalApk false
+             }
+         }
+      }
+      """.trimIndent()
+    )
+
+    val result = testProjectRoot.gradleRunner()
+      .withArguments(":printYml")
+      .build()
+
+    assertThat(result.output).contains("SUCCESS")
+    // Ensure that:
+    // - Any application modules that use ABI splits use APKs for the specified split (armeabi-v7a).
+    // - Any application modules that don't use ABI splits are still present in additional-app-test-apks.
+    assertThat(result.output).containsMatch(
+      """
+     > Task :printYml
+     gcloud:
+       app: [0-9a-zA-Z\/_]*/android-project/build/outputs/apk/debug/android-project-debug.apk
+       test: [0-9a-zA-Z\/_]*/android-project/build/outputs/apk/androidTest/debug/android-project-debug-androidTest.apk
+       device:
+       - model: NexusLowRes
+         version: 28
+
+       use-orchestrator: false
+       auto-google-login: false
+       record-video: true
+       performance-metrics: true
+       timeout: 15m
+       num-flaky-test-attempts: 0
+
+     flank:
+       keep-file-path: false
+       additional-app-test-apks:
+         - app: [0-9a-zA-Z\/_]*/android-project-with-abi-splits/build/outputs/apk/debug/android-project-with-abi-splits-armeabi-v7a-debug.apk
+           test: [0-9a-zA-Z\/_]*/android-project-with-abi-splits/build/outputs/apk/androidTest/debug/android-project-with-abi-splits-debug-androidTest.apk
+
+         - app: [0-9a-zA-Z\/_]*/android-project2/build/outputs/apk/debug/android-project2-debug.apk
+           test: [0-9a-zA-Z\/_]*/android-project2/build/outputs/apk/androidTest/debug/android-project2-debug-androidTest.apk
+           max-test-shards: 5
+           environment-variables:
+             clearPackageData: false
+
+         - test: [0-9a-zA-Z\/_]*/android-library-project/build/outputs/apk/androidTest/debug/android-library-project-debug-androidTest.apk
+
+       ignore-failed-tests: false
+       disable-sharding: false
+       smart-flank-disable-upload: false
+       legacy-junit-result: false
+       full-junit-result: false
+       output-style: single
+      """.trimIndent()
+    )
+  }
 }

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/VariantTests.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/VariantTests.kt
@@ -80,7 +80,6 @@ class VariantTests {
   @Test
   fun testAbiSplits() {
     val result = setUpDependOnAssemble(true, withAbiSplit = true, withTask = "printYml", dryRun = false)
-    // app: /private/var/folders/m2/7q9pbw453p19bpl150ntdfr40000gp/T/junit653698850800487872/build/outputs/apk/debug/junit653698850800487872-x86-debug.apk
     assertThat(result.output).containsMatch("""\s+app: \S*-x86-debug\.apk""")
     // Test APKs do not use ABI splits.
     assertThat(result.output).doesNotContainMatch("""\s+test: \S*-x86-\S*androidTest\.apk""")
@@ -89,7 +88,6 @@ class VariantTests {
   @Test
   fun testAbiSplitsWithVariants() {
     val result = setUpDependOnAssemble(true, withFlavors = true, withAbiSplit = true, withTask = "printYml", dryRun = false)
-    // app: /private/var/folders/m2/7q9pbw453p19bpl150ntdfr40000gp/T/junit6930313466230424292/build/outputs/apk/chocolate/debug/junit6930313466230424292-chocolate-x86-debug.apk
     assertThat(result.output).containsMatch("""\s+app: \S*-chocolate-x86-debug\.apk""")
     assertThat(result.output).doesNotContainMatch("""\s+test: \S*-x86-\S*androidTest\.apk""")
   }


### PR DESCRIPTION
### Background
The Android Gradle Plugin has a feature called ["APK splits"](https://developer.android.com/studio/build/configure-apk-splits): it can generate multiple APKs for a single build variant based on a few well-defined dimensions, such as device ABI or screen density. When APK splits are enabled, the collection returned by `BaseVariant#getOutputs()` contains multiple APK files.

Currently, an app that uses APK splits will experience two issues:
- When using the `Fladle` plugin, if the `debugApk` path is not specified and instead derived from the specified variant, the APK split that is selected is unspecified -- it will be the first in the `BaseVariant#getOutputs()` collection.
- When using the `Fulladle` plugin, each split APK for an application module will be added to `additional-app-test-apks` separately. Here's what the generated flank yml looks like on our project:
```
> Task :printYml
gcloud:
  app: /<path>/app/build/outputs/apk/internal/debug/app-internal-arm64-v8a-debug.apk
  test: /<path>/app/build/outputs/apk/androidTest/internal/debug/app-internal-debug-androidTest.apk
# ...
flank:
  # ...
  additional-app-test-apks:
    - app: /<path>/app/build/outputs/apk/internal/debug/app-internal-armeabi-v7a-debug.apk
      test: /<path>/app/build/outputs/apk/androidTest/internal/debug/app-internal-debug-androidTest.apk

    - app: /<path>/app/build/outputs/apk/internal/debug/app-internal-x86-debug.apk
      test: /<path>/app/build/outputs/apk/androidTest/internal/debug/app-internal-debug-androidTest.apk

    - app: /<path>/app/build/outputs/apk/internal/debug/app-internal-x86_64-debug.apk
      test: /<path>/app/build/outputs/apk/androidTest/internal/debug/app-internal-debug-androidTest.apk

    - test: /<path>/features/channel-browser/build/outputs/apk/androidTest/release/channel-browser-release-androidTest.apk

    - test: /<path>/tooling/benchmarks/android/benchmark/build/outputs/apk/androidTest/release/benchmark-release-androidTest.apk
```
(Note that all APK splits of `app-internal-<ABI>-debug.apk` are being tested.)

### Supporting ABI splits
This PR adds an `abi` property to `FladleConfig` to allow users to choose which ABI to use when splits are enabled. (Note that this doesn't add a screen density option -- hopefully people aren't using those as often 😅 ).

With this change, the resulting `Fulladle` yml in our project no longer contains the additional APK splits.
```
> Task :printYml
gcloud:
  app: /<path>/app/build/outputs/apk/internal/debug/app-internal-x86-debug.apk
  test: /<path>/app/build/outputs/apk/androidTest/internal/debug/app-internal-debug-androidTest.apk
  # ...
flank:
  # ...
  additional-app-test-apks:
    - test: /<path>/features/channel-browser/build/outputs/apk/androidTest/release/channel-browser-release-androidTest.apk

    - test: /<path>/tooling/benchmarks/android/benchmark/build/outputs/apk/androidTest/release/benchmark-release-androidTest.apk

```