### PR TITLE
Add variant support to fulladle

### DIFF
--- a/docs/multi-module-testing.md
+++ b/docs/multi-module-testing.md
@@ -35,7 +35,7 @@ Multi module testing can be done by manually specifying [additionalTestApks](/fl
         ```
 
     !!! Warning
-        If using buildFlavors or testing against a non default variant, Fulladle might not test the variant you are expecting.
+        If using buildFlavors or testing against a non default variant, you will need to specify the variant you want to test in the fulladleModuleConfig block.
 
 3. Run the tests.
     First assemble all your debug apks and test apks.
@@ -69,6 +69,7 @@ Fulladle will pick Flank configurations from the `fladle` block in the root `bui
           "clearPackageData": "true"
       ]
       debugApk = "app.apk"
+      variant = "vanillaDebug"
     }
     ```
 === "Kotlin"
@@ -83,6 +84,7 @@ Fulladle will pick Flank configurations from the `fladle` block in the root `bui
         "clearPackageData" to "true"
       ))
       debugApk.set("app.apk")
+      variant.set("vanillaDebug")
     }
     ```
 All of the above configurations are optional, Flank will default to the top-level configurations if you don't override anything here. For details about these configurations, refer to [configuration docs](./configuration.md).

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FulladleModuleExtension.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FulladleModuleExtension.kt
@@ -39,4 +39,10 @@ open class FulladleModuleExtension @Inject constructor(objects: ObjectFactory) {
    * the app under test
    */
   val debugApk: Property<String> = objects.property<String>().convention(null as String?)
+
+  /**
+   * The variant that should be used for the specific module. If nothing is specified any variant
+   * can be a match.
+   */
+  val variant: Property<String> = objects.property<String>().convention(null as String?)
 }

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FulladlePlugin.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FulladlePlugin.kt
@@ -83,67 +83,74 @@ fun configureModule(project: Project, flankGradleExtension: FlankGradleExtension
   // Does anyone test more than one variant per module?
   var addedTestsForModule = false
 
-  // TODO deal with ignored/filtered variants
   testedExtension.testVariants.configureEach testVariant@{
-    testedVariant.outputs
-      .matching { it.isExpectedAbiOutput(flankGradleExtension) }
-      .configureEach app@{
-        if (addedTestsForModule) {
-          return@app
-        }
-        this@testVariant.outputs.configureEach test@{
-          val yml = StringBuilder()
-          // If the debugApk isn't yet set, let's use this one.
-          if (!flankGradleExtension.debugApk.isPresent) {
-            if (project.isAndroidAppModule) {
-              // app modules produce app apks that we can consume
-              flankGradleExtension.debugApk.set(rootProject.provider { this@app.outputFile.absolutePath })
-            } else if (project.isAndroidLibraryModule) {
-              // library modules do not produce an app apk and we'll use the one specified in fulladleModuleConfig block
-              // we need library modules to specify the app apk to test against, even if it's a dummy one
-              check(fulladleModuleExtension.debugApk.isPresent && fulladleModuleExtension.debugApk.orNull != null) {
-                "Library module ${project.path} did not specify a debug apk. Library modules do not generate a debug apk and one needs to be specified in the fulladleModuleConfig block\nThis is a required parameter in FTL which remains unused for library modules under test, and you can use a dummy apk here"
-              }
-              flankGradleExtension.debugApk.set(rootProject.provider { fulladleModuleExtension.debugApk.get() })
-            }
-          } else {
-            // Otherwise, let's just add it to the list.
-            if (project.isAndroidAppModule) {
-              yml.appendLine("- app: ${this@app.outputFile}")
-            } else if (project.isAndroidLibraryModule) {
-              // app apk is not required for library modules so only use if it's explicitly specified
-              if (fulladleModuleExtension.debugApk.orNull != null) {
-                yml.appendLine("- app: ${fulladleModuleExtension.debugApk.get()}")
-              }
-            }
+    if (this.isExpectedVariantInModule(fulladleModuleExtension)) {
+      testedVariant.outputs
+        .matching { it.isExpectedAbiOutput(flankGradleExtension) }
+        .configureEach app@{
+          if (addedTestsForModule) {
+            return@app
           }
-
-          // If the instrumentation apk isn't yet set, let's use this one.
-          if (!flankGradleExtension.instrumentationApk.isPresent) {
-            flankGradleExtension.instrumentationApk.set(rootProject.provider { this@test.outputFile.absolutePath })
-          } else {
-            // Otherwise, let's just add it to the list.
-            if (yml.isBlank()) {
-              // The first item in the list needs to start with a ` - `.
-              yml.appendLine("- test: ${this@test.outputFile}")
+          this@testVariant.outputs.configureEach test@{
+            val yml = StringBuilder()
+            // If the debugApk isn't yet set, let's use this one.
+            if (!flankGradleExtension.debugApk.isPresent) {
+              if (project.isAndroidAppModule) {
+                // app modules produce app apks that we can consume
+                flankGradleExtension.debugApk.set(rootProject.provider { this@app.outputFile.absolutePath })
+              } else if (project.isAndroidLibraryModule) {
+                // library modules do not produce an app apk and we'll use the one specified in fulladleModuleConfig block
+                // we need library modules to specify the app apk to test against, even if it's a dummy one
+                check(fulladleModuleExtension.debugApk.isPresent && fulladleModuleExtension.debugApk.orNull != null) {
+                  "Library module ${project.path} did not specify a debug apk. Library modules do not generate a debug apk and one needs to be specified in the fulladleModuleConfig block\nThis is a required parameter in FTL which remains unused for library modules under test, and you can use a dummy apk here"
+                }
+                flankGradleExtension.debugApk.set(rootProject.provider { fulladleModuleExtension.debugApk.get() })
+              }
             } else {
-              yml.appendLine("      test: ${this@test.outputFile}")
+              // Otherwise, let's just add it to the list.
+              if (project.isAndroidAppModule) {
+                yml.appendLine("- app: ${this@app.outputFile}")
+              } else if (project.isAndroidLibraryModule) {
+                // app apk is not required for library modules so only use if it's explicitly specified
+                if (fulladleModuleExtension.debugApk.orNull != null) {
+                  yml.appendLine("- app: ${fulladleModuleExtension.debugApk.get()}")
+                }
+              }
             }
-          }
 
-          if (yml.isEmpty()) {
-            // this is the root module
-            // should not be added as additional test apk
-            overrideRootLevelConfigs(flankGradleExtension, fulladleModuleExtension)
-          } else {
-            yml.appendProperty(fulladleModuleExtension.maxTestShards, "    max-test-shards")
-            yml.appendMapProperty(fulladleModuleExtension.clientDetails, "    client-details") { appendLine("        ${it.key}: ${it.value}") }
-            yml.appendMapProperty(fulladleModuleExtension.environmentVariables, "    environment-variables") { appendLine("        ${it.key}: ${it.value}") }
-            flankGradleExtension.additionalTestApks.add(yml.toString())
+            // If the instrumentation apk isn't yet set, let's use this one.
+            if (!flankGradleExtension.instrumentationApk.isPresent) {
+              flankGradleExtension.instrumentationApk.set(rootProject.provider { this@test.outputFile.absolutePath })
+            } else {
+              // Otherwise, let's just add it to the list.
+              if (yml.isBlank()) {
+                // The first item in the list needs to start with a ` - `.
+                yml.appendLine("- test: ${this@test.outputFile}")
+              } else {
+                yml.appendLine("      test: ${this@test.outputFile}")
+              }
+            }
+
+            if (yml.isEmpty()) {
+              // this is the root module
+              // should not be added as additional test apk
+              overrideRootLevelConfigs(flankGradleExtension, fulladleModuleExtension)
+            } else {
+              yml.appendProperty(fulladleModuleExtension.maxTestShards, "    max-test-shards")
+              yml.appendMapProperty(
+                fulladleModuleExtension.clientDetails,
+                "    client-details"
+              ) { appendLine("        ${it.key}: ${it.value}") }
+              yml.appendMapProperty(
+                fulladleModuleExtension.environmentVariables,
+                "    environment-variables"
+              ) { appendLine("        ${it.key}: ${it.value}") }
+              flankGradleExtension.additionalTestApks.add(yml.toString())
+            }
+            addedTestsForModule = true
           }
-          addedTestsForModule = true
         }
-      }
+    }
   }
 }
 

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/Variants.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/Variants.kt
@@ -23,3 +23,11 @@ fun BaseVariantOutput.isExpectedAbiOutput(config: FladleConfig): Boolean {
     !filterTypes.contains(VariantOutput.FilterType.ABI.name) ||
     filters.single { it.filterType == VariantOutput.FilterType.ABI.name }.identifier == config.abi.get()
 }
+
+/**
+ * Returns true if this [BaseVariant] matches the variant specified in the [config].
+ *
+ * If no variant is specified, all variants are considered a match.
+ */
+fun BaseVariant.isExpectedVariantInModule(config: FulladleModuleExtension) =
+  !config.variant.isPresent || (config.variant.isPresent && this.name.contains(config.variant.get()))

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FulladlePluginIntegrationTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FulladlePluginIntegrationTest.kt
@@ -329,11 +329,13 @@ class FulladlePluginIntegrationTest {
     val appFixture = "android-project"
     val libraryFixture = "android-library-project"
     val flavourProject = "android-project-flavors"
+    val flavourLibrary = "android-library-project-flavors"
     testProjectRoot.newFile("settings.gradle").writeText(
       """
       include '$appFixture'
       include '$libraryFixture'       
       include '$flavourProject'
+      include '$flavourLibrary'     
       
       dependencyResolutionManagement {
         repositories {
@@ -346,6 +348,7 @@ class FulladlePluginIntegrationTest {
     testProjectRoot.setupFixture(appFixture)
     testProjectRoot.setupFixture(libraryFixture)
     testProjectRoot.setupFixture(flavourProject)
+    testProjectRoot.setupFixture(flavourLibrary)
 
     writeBuildGradle(
       """
@@ -370,11 +373,19 @@ class FulladlePluginIntegrationTest {
       """.trimIndent()
     )
 
-    // Configure second included project to ignore fulladle module
+    // Configure flavors in project and library
     File(testProjectRoot.root, "$flavourProject/build.gradle").appendText(
       """
       fulladleModuleConfig {
         variant = "vanillaDebug"
+      }
+      """.trimIndent()
+    )
+
+    File(testProjectRoot.root, "$flavourLibrary/build.gradle").appendText(
+      """
+      fulladleModuleConfig {
+        variant = "strawberryDebug"
       }
       """.trimIndent()
     )
@@ -384,7 +395,6 @@ class FulladlePluginIntegrationTest {
       .build()
 
     assertThat(result.output).contains("SUCCESS")
-    // Ensure that there is only one additional test APK even though there are two library modules.
     assertThat(result.output).containsMatch(
       """
      > Task :printYml
@@ -410,6 +420,8 @@ class FulladlePluginIntegrationTest {
 
          - test: [0-9a-zA-Z\/_]*/android-library-project/build/outputs/apk/androidTest/debug/android-library-project-debug-androidTest.apk
 
+         - test: [0-9a-zA-Z\/_]*/android-library-project-flavors/build/outputs/apk/androidTest/strawberry/debug/android-library-project-flavors-strawberry-debug-androidTest.apk
+
        ignore-failed-tests: false
        disable-sharding: false
        smart-flank-disable-upload: false
@@ -425,11 +437,13 @@ class FulladlePluginIntegrationTest {
     val appFixture = "android-project"
     val libraryFixture = "android-library-project"
     val flavourProject = "android-project-flavors"
+    val flavourLibrary = "android-library-project-flavors"
     testProjectRoot.newFile("settings.gradle").writeText(
       """
       include '$appFixture'
       include '$libraryFixture'
       include '$flavourProject'
+      include '$flavourLibrary'
       
       dependencyResolutionManagement {
         repositories {
@@ -440,8 +454,8 @@ class FulladlePluginIntegrationTest {
       """.trimIndent()
     )
     testProjectRoot.setupFixture(appFixture)
-    testProjectRoot.setupFixture(libraryFixture)
     testProjectRoot.setupFixture(flavourProject)
+    testProjectRoot.setupFixture(flavourLibrary)
 
     writeBuildGradle(
       """
@@ -471,7 +485,6 @@ class FulladlePluginIntegrationTest {
       .build()
 
     assertThat(result.output).contains("SUCCESS")
-    // Ensure that there is only one additional test APK even though there are two library modules.
     assertThat(result.output).containsMatch(
       """
      > Task :printYml
@@ -495,7 +508,7 @@ class FulladlePluginIntegrationTest {
          - app: [0-9a-zA-Z\/_]*/android-project-flavors/build/outputs/apk/chocolate/debug/android-project-flavors-chocolate-debug.apk
            test: [0-9a-zA-Z\/_]*/android-project-flavors/build/outputs/apk/androidTest/chocolate/debug/android-project-flavors-chocolate-debug-androidTest.apk
 
-         - test: [0-9a-zA-Z\/_]*/android-library-project/build/outputs/apk/androidTest/debug/android-library-project-debug-androidTest.apk
+         - test: [0-9a-zA-Z\/_]*/android-library-project-flavors/build/outputs/apk/androidTest/lemon/debug/android-library-project-flavors-lemon-debug-androidTest.apk
 
        ignore-failed-tests: false
        disable-sharding: false

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FulladlePluginIntegrationTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FulladlePluginIntegrationTest.kt
@@ -325,6 +325,189 @@ class FulladlePluginIntegrationTest {
   }
 
   @Test
+  fun fulladleWithSpecificFlavor() {
+    val appFixture = "android-project"
+    val libraryFixture = "android-library-project"
+    val flavourProject = "android-project-flavors"
+    testProjectRoot.newFile("settings.gradle").writeText(
+      """
+      include '$appFixture'
+      include '$libraryFixture'       
+      include '$flavourProject'
+      
+      dependencyResolutionManagement {
+        repositories {
+          mavenCentral()
+          google()
+        }
+      }
+      """.trimIndent()
+    )
+    testProjectRoot.setupFixture(appFixture)
+    testProjectRoot.setupFixture(libraryFixture)
+    testProjectRoot.setupFixture(flavourProject)
+
+    writeBuildGradle(
+      """
+      buildscript {
+          repositories {
+              google()
+          }
+  
+          dependencies {
+              classpath '$agpDependency'
+          }
+      }
+      
+      plugins {
+        id "com.osacky.fulladle"
+      }
+      
+      
+      fladle {
+        serviceAccountCredentials = project.layout.projectDirectory.file("android-project/flank-gradle-5cf02dc90531.json")
+      }
+      """.trimIndent()
+    )
+
+    // Configure second included project to ignore fulladle module
+    File(testProjectRoot.root, "$flavourProject/build.gradle").appendText(
+      """
+      fulladleModuleConfig {
+        variant = "vanillaDebug"
+      }
+      """.trimIndent()
+    )
+
+    val result = testProjectRoot.gradleRunner()
+      .withArguments(":printYml")
+      .build()
+
+    assertThat(result.output).contains("SUCCESS")
+    // Ensure that there is only one additional test APK even though there are two library modules.
+    assertThat(result.output).containsMatch(
+      """
+     > Task :printYml
+     gcloud:
+       app: [0-9a-zA-Z\/_]*/android-project/build/outputs/apk/debug/android-project-debug.apk
+       test: [0-9a-zA-Z\/_]*/android-project/build/outputs/apk/androidTest/debug/android-project-debug-androidTest.apk
+       device:
+       - model: NexusLowRes
+         version: 28
+
+       use-orchestrator: false
+       auto-google-login: false
+       record-video: true
+       performance-metrics: true
+       timeout: 15m
+       num-flaky-test-attempts: 0
+
+     flank:
+       keep-file-path: false
+       additional-app-test-apks:
+         - app: [0-9a-zA-Z\/_]*/android-project-flavors/build/outputs/apk/vanilla/debug/android-project-flavors-vanilla-debug.apk
+           test: [0-9a-zA-Z\/_]*/android-project-flavors/build/outputs/apk/androidTest/vanilla/debug/android-project-flavors-vanilla-debug-androidTest.apk
+
+         - test: [0-9a-zA-Z\/_]*/android-library-project/build/outputs/apk/androidTest/debug/android-library-project-debug-androidTest.apk
+
+       ignore-failed-tests: false
+       disable-sharding: false
+       smart-flank-disable-upload: false
+       legacy-junit-result: false
+       full-junit-result: false
+       output-style: single
+      """.trimIndent()
+    )
+  }
+
+  @Test
+  fun fulladleWithDefaultFlavor() {
+    val appFixture = "android-project"
+    val libraryFixture = "android-library-project"
+    val flavourProject = "android-project-flavors"
+    testProjectRoot.newFile("settings.gradle").writeText(
+      """
+      include '$appFixture'
+      include '$libraryFixture'
+      include '$flavourProject'
+      
+      dependencyResolutionManagement {
+        repositories {
+          mavenCentral()
+          google()
+        }
+      }
+      """.trimIndent()
+    )
+    testProjectRoot.setupFixture(appFixture)
+    testProjectRoot.setupFixture(libraryFixture)
+    testProjectRoot.setupFixture(flavourProject)
+
+    writeBuildGradle(
+      """
+      buildscript {
+          repositories {
+              google()
+          }
+  
+          dependencies {
+              classpath '$agpDependency'
+          }
+      }
+      
+      plugins {
+        id "com.osacky.fulladle"
+      }
+      
+      
+      fladle {
+        serviceAccountCredentials = project.layout.projectDirectory.file("android-project/flank-gradle-5cf02dc90531.json")
+      }
+      """.trimIndent()
+    )
+
+    val result = testProjectRoot.gradleRunner()
+      .withArguments(":printYml")
+      .build()
+
+    assertThat(result.output).contains("SUCCESS")
+    // Ensure that there is only one additional test APK even though there are two library modules.
+    assertThat(result.output).containsMatch(
+      """
+     > Task :printYml
+     gcloud:
+       app: [0-9a-zA-Z\/_]*/android-project/build/outputs/apk/debug/android-project-debug.apk
+       test: [0-9a-zA-Z\/_]*/android-project/build/outputs/apk/androidTest/debug/android-project-debug-androidTest.apk
+       device:
+       - model: NexusLowRes
+         version: 28
+
+       use-orchestrator: false
+       auto-google-login: false
+       record-video: true
+       performance-metrics: true
+       timeout: 15m
+       num-flaky-test-attempts: 0
+
+     flank:
+       keep-file-path: false
+       additional-app-test-apks:
+         - app: [0-9a-zA-Z\/_]*/android-project-flavors/build/outputs/apk/chocolate/debug/android-project-flavors-chocolate-debug.apk
+           test: [0-9a-zA-Z\/_]*/android-project-flavors/build/outputs/apk/androidTest/chocolate/debug/android-project-flavors-chocolate-debug-androidTest.apk
+
+         - test: [0-9a-zA-Z\/_]*/android-library-project/build/outputs/apk/androidTest/debug/android-library-project-debug-androidTest.apk
+
+       ignore-failed-tests: false
+       disable-sharding: false
+       smart-flank-disable-upload: false
+       legacy-junit-result: false
+       full-junit-result: false
+       output-style: single
+      """.trimIndent()
+    )
+  }
+
+  @Test
   fun `test root level module overrides with fulladleModuleConfig`() {
     val appFixture = "android-project"
     testProjectRoot.newFile("settings.gradle").writeText(

--- a/fladle-plugin/src/test/resources/android-library-project-flavors/build.gradle
+++ b/fladle-plugin/src/test/resources/android-library-project-flavors/build.gradle
@@ -1,0 +1,36 @@
+plugins {
+    id 'com.android.library'
+}
+
+android {
+    compileSdkVersion 29
+    defaultConfig {
+        targetSdkVersion 29
+        versionCode 1
+        versionName "1.0"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+    testOptions {
+        execution 'ANDROIDX_TEST_ORCHESTRATOR'
+    }
+    flavorDimensions("flavor")
+
+    productFlavors {
+        create("lemon") {
+            dimension = "flavor"
+        }
+        create("strawberry") {
+            dimension = "flavor"
+        }
+    }
+}
+
+dependencies {
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation("androidx.navigation:navigation-fragment-ktx:2.3.0")
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.1'
+    testImplementation 'junit:junit:4.13'
+    androidTestImplementation 'androidx.test:rules:1.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+}

--- a/fladle-plugin/src/test/resources/android-library-project-flavors/src/androidTest/java/com/osacky/flank/gradle/sample/ExampleInstrumentedTest.java
+++ b/fladle-plugin/src/test/resources/android-library-project-flavors/src/androidTest/java/com/osacky/flank/gradle/sample/ExampleInstrumentedTest.java
@@ -1,0 +1,33 @@
+package com.osacky.flank.gradle.sample;
+
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.action.ViewActions.typeText;
+import java.lang.RuntimeException;
+
+@RunWith(AndroidJUnit4.class)
+public class ExampleInstrumentedTest {
+
+  @Rule
+  private final ActivityTestRule testRule = new ActivityTestRule(MainActivity.class);
+
+  @Test
+  public void seeView() {
+    onView(withId(R.id.text_view_hello)).check(matches(isDisplayed()));
+  }
+
+  @Test
+  public void runAndFail() {
+    throw new RuntimeException("Test failed");
+  }
+}

--- a/fladle-plugin/src/test/resources/android-library-project-flavors/src/main/AndroidManifest.xml
+++ b/fladle-plugin/src/test/resources/android-library-project-flavors/src/main/AndroidManifest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="com.osacky.flank.gradle.sample"
+          xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application
+        android:label="@string/app_name"
+    >
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/fladle-plugin/src/test/resources/android-library-project-flavors/src/main/java/com/osacky/flank/gradle/sample/MainActivity.java
+++ b/fladle-plugin/src/test/resources/android-library-project-flavors/src/main/java/com/osacky/flank/gradle/sample/MainActivity.java
@@ -1,0 +1,13 @@
+package com.osacky.flank.gradle.sample;
+
+import androidx.appcompat.app.AppCompatActivity;
+import android.os.Bundle;
+
+public class MainActivity extends AppCompatActivity {
+
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
+  }
+}

--- a/fladle-plugin/src/test/resources/android-library-project-flavors/src/main/res/layout/activity_main.xml
+++ b/fladle-plugin/src/test/resources/android-library-project-flavors/src/main/res/layout/activity_main.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".MainActivity">
+
+    <TextView
+        android:id="@+id/text_view_hello"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Hello World!"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/fladle-plugin/src/test/resources/android-library-project-flavors/src/main/res/values/strings.xml
+++ b/fladle-plugin/src/test/resources/android-library-project-flavors/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Flank Gradle Plugin Sample</string>
+</resources>

--- a/fladle-plugin/src/test/resources/android-project-flavors/build.gradle
+++ b/fladle-plugin/src/test/resources/android-project-flavors/build.gradle
@@ -1,0 +1,40 @@
+plugins {
+    id 'com.android.application'
+    id 'com.osacky.fladle'
+}
+
+android {
+    compileSdkVersion 29
+    defaultConfig {
+        applicationId "com.osacky.flank.gradle.sample"
+        minSdkVersion 23
+        targetSdkVersion 29
+        versionCode 1
+        versionName "1.0"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+    testOptions {
+        execution 'ANDROIDX_TEST_ORCHESTRATOR'
+    }
+    flavorDimensions("flavor")
+
+    productFlavors {
+        create("chocolate") {
+            dimension = "flavor"
+        }
+        create("vanilla") {
+            dimension = "flavor"
+        }
+    }
+}
+
+dependencies {
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation("androidx.navigation:navigation-fragment-ktx:2.3.0")
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.1'
+    testImplementation 'junit:junit:4.13'
+    androidTestImplementation 'androidx.test:rules:1.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+}
+

--- a/fladle-plugin/src/test/resources/android-project-flavors/src/androidTest/java/com/osacky/flank/gradle/sample/ExampleInstrumentedTest.java
+++ b/fladle-plugin/src/test/resources/android-project-flavors/src/androidTest/java/com/osacky/flank/gradle/sample/ExampleInstrumentedTest.java
@@ -1,0 +1,33 @@
+package com.osacky.flank.gradle.sample;
+
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.action.ViewActions.typeText;
+import java.lang.RuntimeException;
+
+@RunWith(AndroidJUnit4.class)
+public class ExampleInstrumentedTest {
+
+  @Rule
+  private final ActivityTestRule testRule = new ActivityTestRule(MainActivity.class);
+
+  @Test
+  public void seeView() {
+    onView(withId(R.id.text_view_hello)).check(matches(isDisplayed()));
+  }
+
+  @Test
+  public void runAndFail() {
+    throw new RuntimeException("Test failed");
+  }
+}

--- a/fladle-plugin/src/test/resources/android-project-flavors/src/main/AndroidManifest.xml
+++ b/fladle-plugin/src/test/resources/android-project-flavors/src/main/AndroidManifest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="com.osacky.flank.gradle.sample"
+          xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application
+        android:label="@string/app_name"
+    >
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/fladle-plugin/src/test/resources/android-project-flavors/src/main/java/com/osacky/flank/gradle/sample/MainActivity.java
+++ b/fladle-plugin/src/test/resources/android-project-flavors/src/main/java/com/osacky/flank/gradle/sample/MainActivity.java
@@ -1,0 +1,13 @@
+package com.osacky.flank.gradle.sample;
+
+import androidx.appcompat.app.AppCompatActivity;
+import android.os.Bundle;
+
+public class MainActivity extends AppCompatActivity {
+
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
+  }
+}

--- a/fladle-plugin/src/test/resources/android-project-flavors/src/main/res/layout/activity_main.xml
+++ b/fladle-plugin/src/test/resources/android-project-flavors/src/main/res/layout/activity_main.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".MainActivity">
+
+    <TextView
+        android:id="@+id/text_view_hello"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Hello World!"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/fladle-plugin/src/test/resources/android-project-flavors/src/main/res/values/strings.xml
+++ b/fladle-plugin/src/test/resources/android-project-flavors/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Flank Gradle Plugin Sample</string>
+</resources>


### PR DESCRIPTION
Currently when using fulladle you cannot specify a variant for a given module which means that you cannot always test the variant that you want to.

This PR adds a new configuration (variant) to fulladle so a variant can be specified for any given module when using fulladle to assure the wanted variant gets tested.