### PR TITLE
Replace deprecated device models and versions

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,8 +69,8 @@ fladle {
     recordVideo = false
     performanceMetrics = false
     devices = [
-        [ "model": "NexusLowRes", "version": "28" ],
-        [ "model": "Nexus5", "version": "23" ]
+        [ "model": "SmallPhone.arm", "version": "28" ],
+        [ "model": "MediumPhone.arm", "version": "33" ]
     ]
     projectId("flank-gradle")
     flankVersion = "{{ fladle.flank_version }}"
@@ -193,15 +193,15 @@ A list of devices to run the tests against. When list is empty, a default device
 === "Groovy"
     ``` groovy
     devices = [
-            [ "model": "Pixel2", "version": "26" ],
-            [ "model": "Nexus5", "version": "23" ]
+            [ "model": "MediumPhone.arm", "version": "26" ],
+            [ "model": "MediumPhone.arm", "version": "33" ]
     ]
     ```
 === "Kotlin"
     ``` kotlin
     devices.set(listOf(
-        mapOf("model" to "Pixel2", "version" to "26" ),
-        mapOf("model" to "Nexus5", "version" to "23" )
+        mapOf("model" to "MediumPhone.arm", "version" to "26" ),
+        mapOf("model" to "MediumPhone.arm", "version" to "33" )
     ))
     ```
 
@@ -490,7 +490,7 @@ A list of paths that will be copied from the device's storage to the designated 
     ```
 
 ### filesToDownload
-List of regex that is matched against bucket paths (for example: `2019-01-09_00:13:06.106000_YCKl/shard_0/NexusLowRes-28-en-portrait/bugreport.txt`) for files to be downloaded after a flank run. The results are downloaded to the `APP_MODULE/build/fladle/RESULTS` directory where RESULTS can be set by [`localResultsDir`](../configuration/#localresultsdir) var otherwise defaulting to `results/`.
+List of regex that is matched against bucket paths (for example: `2019-01-09_00:13:06.106000_YCKl/shard_0/SmallPhone.arm-28-en-portrait/bugreport.txt`) for files to be downloaded after a flank run. The results are downloaded to the `APP_MODULE/build/fladle/RESULTS` directory where RESULTS can be set by [`localResultsDir`](../configuration/#localresultsdir) var otherwise defaulting to `results/`.
 
 === "Groovy"
     ``` groovy

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -27,8 +27,8 @@ This recipe will keep track of test durations automatically on firebase test lab
 
 ## Run different tests on different devices with different Gradle tasks.
 
-`./gradlew runFlankPerfTests` will execute the performance tests against a Nexus5
-`./gradlew runFlankRegresssionTests` will execute the regressions tests against a Nexus5LowRes
+`./gradlew runFlankPerfTests` will execute the performance tests against a MediumPhone.arm
+`./gradlew runFlankRegresssionTests` will execute the regressions tests against a SmallPhone.arm
 
 === "Groovy"
     ``` groovy
@@ -36,8 +36,8 @@ This recipe will keep track of test durations automatically on firebase test lab
         configs {
             perfTests {
                 devices.set([
-                    ["model" : "Nexus5", "version" : "28"], 
-                    ["model" : "Nexus6", "version" : "28"]
+                    ["model" : "MediumPhone.arm", "version" : "28"], 
+                    ["model" : "MediumPhone.arm", "version" : "28"]
                 ])
                 testTargets.set([
                         "class com.sample.MyPerformanceTest"
@@ -45,7 +45,7 @@ This recipe will keep track of test durations automatically on firebase test lab
             }
             regressionTests {
                 devices.set([
-                    [ "model" : "Nexus5LowRes", "version" : "28"]
+                    [ "model" : "SmallPhone.arm", "version" : "28"]
                 ])
                 testTargets.set([
                     "class com.sample.MyRegressionTest"
@@ -60,8 +60,8 @@ This recipe will keep track of test durations automatically on firebase test lab
         configs {
             create("perfTests") {
                 devices.set(listOf(
-                    mapOf("model" to "Nexus5", "version" to "28" ), 
-                    mapOf("model" to "Nexus5", "version" to "28")
+                    mapOf("model" to "MediumPhone.arm", "version" to "28" ), 
+                    mapOf("model" to "MediumPhone.arm", "version" to "28")
                 ))
                 testTargets.set(listOf(
                     "class com.sample.MyPerformanceTest"
@@ -69,7 +69,7 @@ This recipe will keep track of test durations automatically on firebase test lab
             }
             create("regressionTests") {
                 devices.set(listOf(
-                    mapOf("model" to "Nexus5LowRes", "version" to "28" )
+                    mapOf("model" to "SmallPhone.arm", "version" to "28" )
                 ))
                 testTargets.set(listOf(
                     "class com.sample.MyRegressionTest"

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FlankGradleExtension.kt
@@ -36,7 +36,7 @@ open class FlankGradleExtension
     override val autoGoogleLogin: Property<Boolean> = objects.property<Boolean>().convention(false)
     override val devices: ListProperty<Map<String, String>> =
       objects.listProperty<Map<String, String>>().convention(
-        listOf(mapOf("model" to "NexusLowRes", "version" to "28")),
+        listOf(mapOf("model" to "SmallPhone.arm", "version" to "28")),
       )
 
     // https://cloud.google.com/sdk/gcloud/reference/firebase/test/android/run

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/MultipleConfigsTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/MultipleConfigsTest.kt
@@ -54,7 +54,7 @@ class MultipleConfigsTest {
       |  app: foo.apk
       |  test: instrument.apk
       |  device:
-      |  - model: NexusLowRes
+      |  - model: SmallPhone.arm
       |    version: 28
       |
       |  use-orchestrator: false
@@ -92,7 +92,7 @@ class MultipleConfigsTest {
       |  app: foo.apk
       |  test: instrument.apk
       |  device:
-      |  - model: NexusLowRes
+      |  - model: SmallPhone.arm
       |    version: 28
       |
       |  use-orchestrator: false

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/YamlWriterTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/YamlWriterTest.kt
@@ -23,13 +23,13 @@ class YamlWriterTest {
   fun testWriteSingleDevice() {
     val devices =
       listOf(
-        mapOf("model" to "NexusLowRes", "version" to "28"),
+        mapOf("model" to "SmallPhone.arm", "version" to "28"),
       )
     val deviceString = yamlWriter.createDeviceString(devices)
     val expected =
       """
       |  device:
-      |  - model: NexusLowRes
+      |  - model: SmallPhone.arm
       |    version: 28
       |
       """.trimMargin()
@@ -40,17 +40,17 @@ class YamlWriterTest {
   fun testWriteTwoDevices() {
     val devices =
       listOf(
-        mapOf("model" to "NexusLowRes", "version" to "28"),
-        mapOf("model" to "Nexus5", "version" to "23"),
+        mapOf("model" to "SmallPhone.arm", "version" to "28"),
+        mapOf("model" to "MediumPhone.arm", "version" to "33"),
       )
     val deviceString = yamlWriter.createDeviceString(devices)
     val expected =
       """
       |  device:
-      |  - model: NexusLowRes
+      |  - model: SmallPhone.arm
       |    version: 28
-      |  - model: Nexus5
-      |    version: 23
+      |  - model: MediumPhone.arm
+      |    version: 33
       |
       """.trimMargin()
     assertThat(deviceString).isEqualTo(expected)
@@ -60,17 +60,17 @@ class YamlWriterTest {
   fun testWriteTwoCustomDevices() {
     val devices =
       listOf(
-        mapOf("model" to "NexusLowRes", "version" to "23", "orientation" to "portrait"),
-        mapOf("model" to "Nexus5", "orientation" to "landscape", "version" to "28"),
+        mapOf("model" to "SmallPhone.arm", "version" to "33", "orientation" to "portrait"),
+        mapOf("model" to "MediumPhone.arm", "orientation" to "landscape", "version" to "28"),
       )
     val deviceString = yamlWriter.createDeviceString(devices)
     val expected =
       """
       |  device:
-      |  - model: NexusLowRes
-      |    version: 23
+      |  - model: SmallPhone.arm
+      |    version: 33
       |    orientation: portrait
-      |  - model: Nexus5
+      |  - model: MediumPhone.arm
       |    version: 28
       |    orientation: landscape
       |
@@ -82,18 +82,18 @@ class YamlWriterTest {
   fun testWriteTwoCustomDevicesWithLocale() {
     val devices =
       listOf(
-        mapOf("model" to "NexusLowRes", "version" to "23", "orientation" to "portrait", "locale" to "en"),
-        mapOf("model" to "Nexus5", "orientation" to "landscape", "locale" to "es_ES", "version" to "28"),
+        mapOf("model" to "SmallPhone.arm", "version" to "33", "orientation" to "portrait", "locale" to "en"),
+        mapOf("model" to "MediumPhone.arm", "orientation" to "landscape", "locale" to "es_ES", "version" to "28"),
       )
     val deviceString = yamlWriter.createDeviceString(devices)
     val expected =
       """
       |  device:
-      |  - model: NexusLowRes
-      |    version: 23
+      |  - model: SmallPhone.arm
+      |    version: 33
       |    orientation: portrait
       |    locale: en
-      |  - model: Nexus5
+      |  - model: MediumPhone.arm
       |    version: 28
       |    orientation: landscape
       |    locale: es_ES
@@ -120,7 +120,7 @@ class YamlWriterTest {
   fun testThrowsExceptionWhenMissingVersionKeyInDevice() {
     val devices =
       listOf(
-        mapOf("model" to "NexusLowRes", "orientation" to "portrait", "locale" to "en"),
+        mapOf("model" to "SmallPhone.arm", "orientation" to "portrait", "locale" to "en"),
       )
     try {
       yamlWriter.createDeviceString(devices)
@@ -160,7 +160,7 @@ class YamlWriterTest {
         app: path
         test: instrument
         device:
-        - model: NexusLowRes
+        - model: SmallPhone.arm
           version: 28
 
         use-orchestrator: false
@@ -330,7 +330,7 @@ class YamlWriterTest {
       gcloud:
         app: path
         device:
-        - model: NexusLowRes
+        - model: SmallPhone.arm
           version: 28
 
         use-orchestrator: false
@@ -367,7 +367,7 @@ class YamlWriterTest {
       gcloud:
         app: path
         device:
-        - model: NexusLowRes
+        - model: SmallPhone.arm
           version: 28
 
         use-orchestrator: false

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/AutoConfigureFladleTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/AutoConfigureFladleTest.kt
@@ -53,10 +53,10 @@ class AutoConfigureFladleTest {
         app: [0-9a-zA-Z\/_]*/android-project/build/outputs/apk/debug/android-project-debug.apk
         test: [0-9a-zA-Z\/_]*/android-project/build/outputs/apk/androidTest/debug/android-project-debug-androidTest.apk
         device:
-        - model: Pixel2
+        - model: SmallPhone.arm
           version: 26
-        - model: Nexus5
-          version: 23
+        - model: MediumPhone.arm
+          version: 33
 
         use-orchestrator: true
         auto-google-login: false

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FulladlePluginIntegrationTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FulladlePluginIntegrationTest.kt
@@ -101,7 +101,7 @@ class FulladlePluginIntegrationTest {
         app: [0-9a-zA-Z\/_]*/android-project/build/outputs/apk/debug/android-project-debug.apk
         test: [0-9a-zA-Z\/_]*/android-project/build/outputs/apk/androidTest/debug/android-project-debug-androidTest.apk
         device:
-        - model: NexusLowRes
+        - model: SmallPhone.arm
           version: 28
 
         use-orchestrator: false
@@ -283,7 +283,7 @@ class FulladlePluginIntegrationTest {
         app: [0-9a-zA-Z\/_]*/android-project/build/outputs/apk/debug/android-project-debug.apk
         test: [0-9a-zA-Z\/_]*/android-project/build/outputs/apk/androidTest/debug/android-project-debug-androidTest.apk
         device:
-        - model: NexusLowRes
+        - model: SmallPhone.arm
           version: 28
 
         use-orchestrator: false
@@ -407,7 +407,7 @@ class FulladlePluginIntegrationTest {
         app: [0-9a-zA-Z\/_]*/android-project/build/outputs/apk/debug/android-project-debug.apk
         test: [0-9a-zA-Z\/_]*/android-project/build/outputs/apk/androidTest/debug/android-project-debug-androidTest.apk
         device:
-        - model: NexusLowRes
+        - model: SmallPhone.arm
           version: 28
 
         use-orchestrator: false
@@ -498,7 +498,7 @@ class FulladlePluginIntegrationTest {
         app: [0-9a-zA-Z\/_]*/android-project/build/outputs/apk/debug/android-project-debug.apk
         test: [0-9a-zA-Z\/_]*/android-project/build/outputs/apk/androidTest/debug/android-project-debug-androidTest.apk
         device:
-        - model: NexusLowRes
+        - model: SmallPhone.arm
           version: 28
 
         use-orchestrator: false
@@ -982,7 +982,7 @@ class FulladlePluginIntegrationTest {
         app: [0-9a-zA-Z\/_]*/android-project/build/outputs/apk/debug/android-project-debug.apk
         test: [0-9a-zA-Z\/_]*/android-project/build/outputs/apk/androidTest/debug/android-project-debug-androidTest.apk
         device:
-        - model: NexusLowRes
+        - model: SmallPhone.arm
           version: 28
 
         use-orchestrator: false

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/SanityRoboTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/SanityRoboTest.kt
@@ -209,7 +209,7 @@ class SanityRoboTest {
       |  app: foo.apk
       |  test: test.apk
       |  device:
-      |  - model: NexusLowRes
+      |  - model: SmallPhone.arm
       |    version: 28
       |
       |  use-orchestrator: false
@@ -242,7 +242,7 @@ class SanityRoboTest {
       |gcloud:
       |  app: foo.apk
       |  device:
-      |  - model: NexusLowRes
+      |  - model: SmallPhone.arm
       |    version: 28
       |
       |  use-orchestrator: false
@@ -300,7 +300,7 @@ class SanityRoboTest {
       |gcloud:
       |  app: foo.apk
       |  device:
-      |  - model: NexusLowRes
+      |  - model: SmallPhone.arm
       |    version: 28
       |
       |  use-orchestrator: false
@@ -330,7 +330,7 @@ class SanityRoboTest {
       |  app: foo.apk
       |  test: test.apk
       |  device:
-      |  - model: NexusLowRes
+      |  - model: SmallPhone.arm
       |    version: 28
       |
       |  use-orchestrator: false

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/SanityWithAutoConfigureTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/SanityWithAutoConfigureTest.kt
@@ -56,8 +56,8 @@ class SanityWithAutoConfigureTest {
                 "class com.osacky.flank.gradle.sample.ExampleInstrumentedTest#seeView"
               ]
               devices = [
-                [ "model": "Pixel2", "version": "26" ],
-                [ "model": "Nexus5", "version": "23" ]
+                [ "model": "SmallPhone.arm", "version": "26" ],
+                [ "model": "MediumPhone.arm", "version": "33" ]
               ]
               smartFlankGcsPath = "gs://test-lab-yr9w6qsdvy45q-iurp80dm95h8a/flank/test_app_android.xml"
               configs {
@@ -91,10 +91,10 @@ class SanityWithAutoConfigureTest {
         app: [0-9a-zA-Z\/_]*/build/outputs/apk/debug/[0-9a-zA-Z\/_]*-debug.apk
         test: [0-9a-zA-Z\/_]*/build/outputs/apk/androidTest/debug/[0-9a-zA-Z\/_]*-debug-androidTest.apk
         device:
-        - model: Pixel2
+        - model: SmallPhone.arm
           version: 26
-        - model: Nexus5
-          version: 23
+        - model: MediumPhone.arm
+          version: 33
 
         use-orchestrator: true
         auto-google-login: false
@@ -127,10 +127,10 @@ class SanityWithAutoConfigureTest {
       gcloud:
         app: [0-9a-zA-Z\/_]*/build/outputs/apk/debug/[0-9a-zA-Z\/_]*-debug.apk
         device:
-        - model: Pixel2
+        - model: SmallPhone.arm
           version: 26
-        - model: Nexus5
-          version: 23
+        - model: MediumPhone.arm
+          version: 33
 
         use-orchestrator: false
         auto-google-login: false
@@ -164,10 +164,10 @@ class SanityWithAutoConfigureTest {
         app: [0-9a-zA-Z\/_]*/build/outputs/apk/debug/[0-9a-zA-Z\/_]*-debug.apk
         test: [0-9a-zA-Z\/_]*/build/outputs/apk/androidTest/debug/[0-9a-zA-Z\/_]*-debug-androidTest.apk
         device:
-        - model: Pixel2
+        - model: SmallPhone.arm
           version: 26
-        - model: Nexus5
-          version: 23
+        - model: MediumPhone.arm
+          version: 33
 
         use-orchestrator: false
         auto-google-login: false
@@ -210,8 +210,8 @@ class SanityWithAutoConfigureTest {
                 "class com.osacky.flank.gradle.sample.ExampleInstrumentedTest#seeView"
               ]
               devices = [
-                [ "model": "Pixel2", "version": "26" ],
-                [ "model": "Nexus5", "version": "23" ]
+                [ "model": "SmallPhone.arm", "version": "26" ],
+                [ "model": "MediumPhone.arm", "version": "33" ]
               ]
               smartFlankGcsPath = "gs://test-lab-yr9w6qsdvy45q-iurp80dm95h8a/flank/test_app_android.xml"
               configs {
@@ -238,10 +238,10 @@ class SanityWithAutoConfigureTest {
       gcloud:
         app: [0-9a-zA-Z\/_]*/build/outputs/apk/debug/[0-9a-zA-Z\/_]*-debug.apk
         device:
-        - model: Pixel2
+        - model: SmallPhone.arm
           version: 26
-        - model: Nexus5
-          version: 23
+        - model: MediumPhone.arm
+          version: 33
 
         use-orchestrator: true
         auto-google-login: false
@@ -275,10 +275,10 @@ class SanityWithAutoConfigureTest {
         app: [0-9a-zA-Z\/_]*/build/outputs/apk/debug/[0-9a-zA-Z\/_]*-debug.apk
         test: instrumentation-apk-not-detected-from-root.apk
         device:
-        - model: Pixel2
+        - model: SmallPhone.arm
           version: 26
-        - model: Nexus5
-          version: 23
+        - model: MediumPhone.arm
+          version: 33
 
         use-orchestrator: false
         auto-google-login: false

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/validation/ValidateOptionsTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/validation/ValidateOptionsTest.kt
@@ -134,7 +134,7 @@ class ValidateOptionsTest {
       |  app: foo.apk
       |  test: test.apk
       |  device:
-      |  - model: NexusLowRes
+      |  - model: SmallPhone.arm
       |    version: 28
       |
       |  use-orchestrator: false
@@ -164,7 +164,7 @@ class ValidateOptionsTest {
       |  app: foo.apk
       |  test: test.apk
       |  device:
-      |  - model: NexusLowRes
+      |  - model: SmallPhone.arm
       |    version: 28
       |
       |  use-orchestrator: false

--- a/fladle-plugin/src/test/resources/android-project/build.gradle
+++ b/fladle-plugin/src/test/resources/android-project/build.gradle
@@ -30,8 +30,8 @@ fladle {
             "class com.osacky.flank.gradle.sample.ExampleInstrumentedTest#seeView"
     ]
     devices = [
-            [ "model": "Pixel2", "version": "26" ],
-            [ "model": "Nexus5", "version": "23" ]
+            [ "model": "SmallPhone.arm", "version": "26" ],
+            [ "model": "MediumPhone.arm", "version": "33" ]
     ]
     smartFlankGcsPath = "gs://test-lab-yr9w6qsdvy45q-iurp80dm95h8a/flank/test_app_android.xml"
     configs {

--- a/fladle-plugin/src/test/resources/android-project2/build.gradle
+++ b/fladle-plugin/src/test/resources/android-project2/build.gradle
@@ -29,8 +29,8 @@ fladle {
             "class com.osacky.flank.gradle.sample.ExampleInstrumentedTest#seeView"
     ]
     devices = [
-            [ "model": "Pixel2", "version": "26" ],
-            [ "model": "Nexus5", "version": "23" ]
+            [ "model": "SmallPhone.arm", "version": "26" ],
+            [ "model": "MediumPhone.arm", "version": "33" ]
     ]
     smartFlankGcsPath = "gs://test-lab-yr9w6qsdvy45q-iurp80dm95h8a/flank/test_app_android.xml"
     configs {

--- a/sample-flavors-kotlin/build.gradle.kts
+++ b/sample-flavors-kotlin/build.gradle.kts
@@ -57,8 +57,8 @@ fladle {
             "class com.osacky.flank.gradle.sample.ExampleInstrumentedTest#seeView"
     ) })
     devices.set(project.provider { listOf(
-        mapOf("model" to "Pixel2", "version" to "26" ),
-        mapOf("model" to "Nexus5", "version" to "23" )
+        mapOf("model" to "SmallPhone.arm", "version" to "26" ),
+        mapOf("model" to "MediumPhone.arm", "version" to "33" )
     ) })
     smartFlankGcsPath.set("gs://test-lab-yr9w6qsdvy45q-iurp80dm95h8a/flank/test_app_android.xml")
     configs {

--- a/sample-kotlin/build.gradle.kts
+++ b/sample-kotlin/build.gradle.kts
@@ -38,8 +38,8 @@ fladle {
             "class com.osacky.flank.gradle.sample.ExampleInstrumentedTest#seeView"
     ))
     devices.set(listOf(
-        mapOf("model" to "Pixel2", "version" to "26" ),
-        mapOf("model" to "Nexus5", "version" to "23" )
+        mapOf("model" to "SmallPhone.arm", "version" to "26" ),
+        mapOf("model" to "MediumPhone.arm", "version" to "33" )
     ))
     smartFlankGcsPath.set("gs://test-lab-yr9w6qsdvy45q-iurp80dm95h8a/flank/test_app_android.xml")
     configs {
@@ -61,13 +61,13 @@ fladle {
             )})
         }
         create("perfTests") {
-            devices.set(listOf(mapOf("model" to "Nexus5", "version" to "28" ), mapOf("model" to "Nexus5", "version" to "28")))
+            devices.set(listOf(mapOf("model" to "SmallPhone.arm", "version" to "28" ), mapOf("model" to "MediumPhone.arm", "version" to "33")))
             testTargets.set(listOf(
                 "class com.sample.MyPerformanceTest"
             ))
         }
         create("regressionTests") {
-            devices.set(listOf(mapOf("model" to "Nexus5LowRes", "version" to "28" )))
+            devices.set(listOf(mapOf("model" to "SmallPhone.arm", "version" to "28" )))
             testTargets.set(listOf(
                 "class com.sample.MyRegressionTest"
             ))

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -42,8 +42,8 @@ fladle {
             "class com.osacky.flank.gradle.sample.ExampleInstrumentedTest#seeView"
     ]
     devices = [
-            [ "model": "Pixel2", "version": "26" ],
-            [ "model": "Nexus5", "version": "23" ]
+            [ "model": "SmallPhone.arm", "version": "26" ],
+            [ "model": "MediumPhone.arm", "version": "33" ]
     ]
     localResultsDir = "foo"
     smartFlankGcsPath = "gs://test-lab-yr9w6qsdvy45q-iurp80dm95h8a/flank/test_app_android.xml"
@@ -72,13 +72,13 @@ fladle {
             ]})
         }
         perfTests {
-            devices.set([[ "model" : "Nexus5", "version" : "28" ], ["model" : "Nexus5", "version": "28"]])
+            devices.set([[ "model" : "SmallPhone.arm", "version" : "28" ], ["model" : "MediumPhone.arm", "version": "33"]])
             testTargets.set([
                     "class com.sample.MyPerformanceTest"
             ])
         }
         regressionTests {
-            devices.set([[ "model" : "Nexus5LowRes", "version" : "28" ]])
+            devices.set([[ "model" : "SmallPhone.arm", "version" : "28" ]])
             testTargets.set([
                     "class com.sample.MyRegressionTest"
             ])


### PR DESCRIPTION
This changes the default from `Pixel2/26` to `MediumPhone.arm/26`.

`Pixel2/26` has been [deprecated](https://firebase.google.com/docs/test-lab/android/available-testing-devices#deprecated) and will be removed 2025-03-31.