### PR TITLE
fix: Fulladle generates wrong APK paths for variants with multiple flavor dimensions

### DIFF
--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FladlePluginDelegate.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FladlePluginDelegate.kt
@@ -238,11 +238,9 @@ class FladlePluginDelegate {
 
     androidComponents.onVariants { variant ->
       if (!variant.isExpectedVariant(config)) return@onVariants
-      val androidTest = (variant as? HasAndroidTest)?.androidTest ?: return@onVariants
+      if ((variant as? HasAndroidTest)?.androidTest == null) return@onVariants
 
       val buildType = variant.buildType ?: return@onVariants
-      val flavorName = variant.productFlavors.joinToString("") { it.second }
-      val flavorPath = variant.productFlavors.joinToString("/") { it.second }
       val archivesName =
         project.extensions
           .getByType(BasePluginExtension::class.java)
@@ -250,17 +248,9 @@ class FladlePluginDelegate {
           .get()
       val buildDir = project.layout.buildDirectory
 
-      // Test APK path
-      val testApkDirPath = if (flavorPath.isNotEmpty()) "androidTest/$flavorPath/$buildType" else "androidTest/$buildType"
-      val testApkFileName =
-        if (flavorName.isNotEmpty()) {
-          "$archivesName-$flavorName-$buildType-androidTest.apk"
-        } else {
-          "$archivesName-$buildType-androidTest.apk"
-        }
       val testApkPath =
         buildDir
-          .file("outputs/apk/$testApkDirPath/$testApkFileName")
+          .file("outputs/apk/${variant.androidTestApkPath(archivesName, buildType)}")
           .get()
           .asFile
           .absolutePath
@@ -271,17 +261,9 @@ class FladlePluginDelegate {
         val abiFilter = output.filters.firstOrNull { it.filterType == FilterConfiguration.FilterType.ABI }
         val abiName = abiFilter?.identifier
 
-        val appApkDirPath = if (flavorPath.isNotEmpty()) "$flavorPath/$buildType" else buildType
-        val appApkFileName =
-          buildString {
-            append(archivesName)
-            if (flavorName.isNotEmpty()) append("-$flavorName")
-            if (abiName != null) append("-$abiName")
-            append("-$buildType.apk")
-          }
         val appApkPath =
           buildDir
-            .file("outputs/apk/$appApkDirPath/$appApkFileName")
+            .file("outputs/apk/${variant.appApkPath(archivesName, buildType, abiName)}")
             .get()
             .asFile
             .absolutePath

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FulladlePlugin.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FulladlePlugin.kt
@@ -30,39 +30,21 @@ class FulladlePlugin : Plugin<Project> {
         androidComponents.onVariants { variant ->
           val androidTest = (variant as? HasAndroidTest)?.androidTest ?: return@onVariants
           val buildType = variant.buildType ?: return@onVariants
-          val flavorName = variant.productFlavors.joinToString("") { it.second }
-          val flavorPath = variant.productFlavors.joinToString("/") { it.second }
           val archivesName = extensions.getByType(BasePluginExtension::class.java).archivesName.get()
 
           variant.outputs.forEach { output ->
             val abiFilter = output.filters.firstOrNull { it.filterType == FilterConfiguration.FilterType.ABI }
             val abiName = abiFilter?.identifier
 
-            val appApkDirPath = if (flavorPath.isNotEmpty()) "$flavorPath/$buildType" else buildType
-            val appApkFileName =
-              buildString {
-                append(archivesName)
-                if (flavorName.isNotEmpty()) append("-$flavorName")
-                if (abiName != null) append("-$abiName")
-                append("-$buildType.apk")
-              }
             val appApkPath =
               layout.buildDirectory
-                .file("outputs/apk/$appApkDirPath/$appApkFileName")
+                .file("outputs/apk/${variant.appApkPath(archivesName, buildType, abiName)}")
                 .get()
                 .asFile.absolutePath
 
-            val testApkDirPath =
-              if (flavorPath.isNotEmpty()) "androidTest/$flavorPath/$buildType" else "androidTest/$buildType"
-            val testApkFileName =
-              if (flavorName.isNotEmpty()) {
-                "$archivesName-$flavorName-$buildType-androidTest.apk"
-              } else {
-                "$archivesName-$buildType-androidTest.apk"
-              }
             val testApkPath =
               layout.buildDirectory
-                .file("outputs/apk/$testApkDirPath/$testApkFileName")
+                .file("outputs/apk/${variant.androidTestApkPath(archivesName, buildType)}")
                 .get()
                 .asFile.absolutePath
 
@@ -84,21 +66,11 @@ class FulladlePlugin : Plugin<Project> {
         androidComponents.onVariants { variant ->
           val androidTest = (variant as? HasAndroidTest)?.androidTest ?: return@onVariants
           val buildType = variant.buildType ?: return@onVariants
-          val flavorName = variant.productFlavors.joinToString("") { it.second }
-          val flavorPath = variant.productFlavors.joinToString("/") { it.second }
           val archivesName = extensions.getByType(BasePluginExtension::class.java).archivesName.get()
 
-          val testApkDirPath =
-            if (flavorPath.isNotEmpty()) "androidTest/$flavorPath/$buildType" else "androidTest/$buildType"
-          val testApkFileName =
-            if (flavorName.isNotEmpty()) {
-              "$archivesName-$flavorName-$buildType-androidTest.apk"
-            } else {
-              "$archivesName-$buildType-androidTest.apk"
-            }
           val testApkPath =
             layout.buildDirectory
-              .file("outputs/apk/$testApkDirPath/$testApkFileName")
+              .file("outputs/apk/${variant.androidTestApkPath(archivesName, buildType)}")
               .get()
               .asFile.absolutePath
 

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/Variants.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/Variants.kt
@@ -25,10 +25,44 @@ fun VariantOutput.isExpectedAbiOutput(config: FladleConfig): Boolean {
     abiFilters.any { it.identifier == config.abi.get() }
 }
 
-/**
- * Returns true if this [Variant] matches the variant specified in the [config].
- *
- * If no variant is specified, all variants are considered a match.
- */
-fun Variant.isExpectedVariantInModule(config: FulladleModuleExtension) =
-  !config.variant.isPresent || (config.variant.isPresent && this.name.contains(config.variant.get()))
+fun Variant.appApkPath(
+  archivesName: String,
+  buildType: String,
+  abiName: String?,
+): String = "${apkDirPath(buildType)}/${appApkFileName(archivesName, buildType, abiName)}"
+
+fun Variant.androidTestApkPath(
+  archivesName: String,
+  buildType: String,
+): String = "androidTest/${apkDirPath(buildType)}/${androidTestApkFileName(archivesName, buildType)}"
+
+private fun Variant.apkDirPath(buildType: String): String {
+  val flavorPath = flavorName.orEmpty()
+  return if (flavorPath.isNotEmpty()) "$flavorPath/$buildType" else buildType
+}
+
+private fun Variant.appApkFileName(
+  archivesName: String,
+  buildType: String,
+  abiName: String?,
+): String =
+  buildString {
+    append(archivesName)
+    val flavorName = flavorFileName()
+    if (flavorName.isNotEmpty()) append("-$flavorName")
+    if (abiName != null) append("-$abiName")
+    append("-$buildType.apk")
+  }
+
+private fun Variant.androidTestApkFileName(
+  archivesName: String,
+  buildType: String,
+): String =
+  buildString {
+    append(archivesName)
+    val flavorName = flavorFileName()
+    if (flavorName.isNotEmpty()) append("-$flavorName")
+    append("-$buildType-androidTest.apk")
+  }
+
+private fun Variant.flavorFileName(): String = productFlavors.joinToString("-") { it.second }

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/AutoConfigureFladleTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/AutoConfigureFladleTest.kt
@@ -83,4 +83,50 @@ class AutoConfigureFladleTest {
       """.trimIndent(),
     )
   }
+
+  @Test
+  fun testAndroidProjectWithMultipleFlavorDimensions() {
+    val fixtureName = "android-project-multiple-flavor-dimensions"
+    testProjectRoot.newFile("local.properties").writeText("sdk.dir=${androidHome()}\n")
+    testProjectRoot.newFile("gradle.properties").writeText("android.useAndroidX=true")
+    writeBuildGradle(
+      """
+      allprojects {
+        repositories {
+          google()
+          mavenCentral()
+        }
+      }
+      """.trimIndent(),
+    )
+    testProjectRoot.newFile("settings.gradle").writeText(
+      """
+      include '$fixtureName'
+      """.trimIndent(),
+    )
+
+    testProjectRoot.setupFixture(fixtureName)
+
+    val result =
+      GradleRunner
+        .create()
+        .withProjectDir(testProjectRoot.root)
+        .withPluginClasspath()
+        .withArguments(
+          ":$fixtureName:assembleMinApi24DemoDebug",
+          ":$fixtureName:assembleMinApi24DemoDebugAndroidTest",
+          ":$fixtureName:printYml",
+          "--stacktrace",
+        ).build()
+
+    assertThat(result.output).contains("BUILD SUCCESSFUL")
+    assertThat(result.output).containsMatch(
+      """app: \S*/android-project-multiple-flavor-dimensions/build/outputs/apk/minApi24Demo/debug/android-project-multiple-flavor-dimensions-minApi24-demo-debug\.apk""",
+    )
+    assertThat(result.output).containsMatch(
+      """test: \S*/android-project-multiple-flavor-dimensions/build/outputs/apk/androidTest/minApi24Demo/debug/android-project-multiple-flavor-dimensions-minApi24-demo-debug-androidTest\.apk""",
+    )
+    assertThat(result.output).doesNotContain("/minApi24/demo/debug/")
+    assertThat(result.output).doesNotContain("-minApi24demo-debug")
+  }
 }

--- a/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FulladlePluginIntegrationTest.kt
+++ b/fladle-plugin/src/test/java/com/osacky/flank/gradle/integration/FulladlePluginIntegrationTest.kt
@@ -443,6 +443,88 @@ class FulladlePluginIntegrationTest {
   }
 
   @Test
+  fun fulladleWithMultipleFlavorDimensions() {
+    val appFixture = "android-project"
+    val flavourProject = "android-project-multiple-flavor-dimensions"
+    val flavourLibrary = "android-library-project-multiple-flavor-dimensions"
+    testProjectRoot.newFile("settings.gradle").writeText(
+      """
+      include '$appFixture'
+      include '$flavourProject'
+      include '$flavourLibrary'
+
+      dependencyResolutionManagement {
+        repositories {
+          mavenCentral()
+          google()
+        }
+      }
+      """.trimIndent(),
+    )
+    testProjectRoot.setupFixture(appFixture)
+    testProjectRoot.setupFixture(flavourProject)
+    testProjectRoot.setupFixture(flavourLibrary)
+
+    writeBuildGradle(
+      """
+      buildscript {
+          repositories {
+              google()
+          }
+
+          dependencies {
+              classpath '$agpDependency'
+          }
+      }
+
+      plugins {
+        id "com.osacky.fulladle"
+      }
+
+      fladle {
+        serviceAccountCredentials = project.layout.projectDirectory.file("android-project/flank-gradle-5cf02dc90531.json")
+      }
+      """.trimIndent(),
+    )
+
+    File(testProjectRoot.root, "$flavourProject/build.gradle").appendText(
+      """
+
+      fulladleModuleConfig {
+        variant = "minApi24DemoDebug"
+      }
+      """.trimIndent(),
+    )
+    File(testProjectRoot.root, "$flavourLibrary/build.gradle").appendText(
+      """
+
+      fulladleModuleConfig {
+        variant = "minApi24DemoDebug"
+      }
+      """.trimIndent(),
+    )
+
+    val result =
+      testProjectRoot
+        .gradleRunner()
+        .withArguments(":printYml")
+        .build()
+
+    assertThat(result.output).contains("SUCCESS")
+    assertThat(result.output).containsMatch(
+      """app: \S*/android-project-multiple-flavor-dimensions/build/outputs/apk/minApi24Demo/debug/android-project-multiple-flavor-dimensions-minApi24-demo-debug\.apk""",
+    )
+    assertThat(result.output).containsMatch(
+      """test: \S*/android-project-multiple-flavor-dimensions/build/outputs/apk/androidTest/minApi24Demo/debug/android-project-multiple-flavor-dimensions-minApi24-demo-debug-androidTest\.apk""",
+    )
+    assertThat(result.output).containsMatch(
+      """test: \S*/android-library-project-multiple-flavor-dimensions/build/outputs/apk/androidTest/minApi24Demo/debug/android-library-project-multiple-flavor-dimensions-minApi24-demo-debug-androidTest\.apk""",
+    )
+    assertThat(result.output).doesNotContain("/minApi24/demo/debug/")
+    assertThat(result.output).doesNotContain("-minApi24demo-debug")
+  }
+
+  @Test
   fun fulladleWithDefaultFlavor() {
     val appFixture = "android-project"
     val libraryFixture = "android-library-project"

--- a/fladle-plugin/src/test/resources/android-library-project-multiple-flavor-dimensions/build.gradle
+++ b/fladle-plugin/src/test/resources/android-library-project-multiple-flavor-dimensions/build.gradle
@@ -1,0 +1,37 @@
+plugins {
+    id 'com.android.library'
+}
+
+android {
+    compileSdk 33
+    namespace = "com.osacky.flank.gradle.sample"
+    defaultConfig {
+        targetSdk 33
+        versionCode 1
+        versionName "1.0"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+    testOptions {
+        execution 'ANDROIDX_TEST_ORCHESTRATOR'
+    }
+    flavorDimensions "api", "mode"
+
+    productFlavors {
+        minApi24 {
+            dimension "api"
+        }
+        demo {
+            dimension "mode"
+        }
+    }
+}
+
+dependencies {
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation("androidx.navigation:navigation-fragment-ktx:2.3.0")
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.1'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test:rules:1.5.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+}

--- a/fladle-plugin/src/test/resources/android-library-project-multiple-flavor-dimensions/src/androidTest/java/com/osacky/flank/gradle/sample/ExampleInstrumentedTest.java
+++ b/fladle-plugin/src/test/resources/android-library-project-multiple-flavor-dimensions/src/androidTest/java/com/osacky/flank/gradle/sample/ExampleInstrumentedTest.java
@@ -1,0 +1,33 @@
+package com.osacky.flank.gradle.sample;
+
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.action.ViewActions.typeText;
+import java.lang.RuntimeException;
+
+@RunWith(AndroidJUnit4.class)
+public class ExampleInstrumentedTest {
+
+  @Rule
+  private final ActivityTestRule testRule = new ActivityTestRule(MainActivity.class);
+
+  @Test
+  public void seeView() {
+    onView(withId(R.id.text_view_hello)).check(matches(isDisplayed()));
+  }
+
+  @Test
+  public void runAndFail() {
+    throw new RuntimeException("Test failed");
+  }
+}

--- a/fladle-plugin/src/test/resources/android-library-project-multiple-flavor-dimensions/src/main/AndroidManifest.xml
+++ b/fladle-plugin/src/test/resources/android-library-project-multiple-flavor-dimensions/src/main/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest
+          xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application
+        android:label="@string/app_name"
+    >
+        <activity android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/fladle-plugin/src/test/resources/android-library-project-multiple-flavor-dimensions/src/main/java/com/osacky/flank/gradle/sample/MainActivity.java
+++ b/fladle-plugin/src/test/resources/android-library-project-multiple-flavor-dimensions/src/main/java/com/osacky/flank/gradle/sample/MainActivity.java
@@ -1,0 +1,13 @@
+package com.osacky.flank.gradle.sample;
+
+import androidx.appcompat.app.AppCompatActivity;
+import android.os.Bundle;
+
+public class MainActivity extends AppCompatActivity {
+
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
+  }
+}

--- a/fladle-plugin/src/test/resources/android-library-project-multiple-flavor-dimensions/src/main/res/layout/activity_main.xml
+++ b/fladle-plugin/src/test/resources/android-library-project-multiple-flavor-dimensions/src/main/res/layout/activity_main.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".MainActivity">
+
+    <TextView
+        android:id="@+id/text_view_hello"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Hello World!"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/fladle-plugin/src/test/resources/android-library-project-multiple-flavor-dimensions/src/main/res/values/strings.xml
+++ b/fladle-plugin/src/test/resources/android-library-project-multiple-flavor-dimensions/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Flank Gradle Plugin Sample</string>
+</resources>

--- a/fladle-plugin/src/test/resources/android-project-multiple-flavor-dimensions/build.gradle
+++ b/fladle-plugin/src/test/resources/android-project-multiple-flavor-dimensions/build.gradle
@@ -1,0 +1,45 @@
+plugins {
+    id 'com.android.application'
+    id 'com.osacky.fladle'
+}
+
+android {
+    compileSdk 33
+    namespace = "com.osacky.flank.gradle.sample"
+    defaultConfig {
+        applicationId "com.osacky.flank.gradle.sample"
+        minSdk 23
+        targetSdk 33
+        versionCode 1
+        versionName "1.0"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+    testOptions {
+        execution 'ANDROIDX_TEST_ORCHESTRATOR'
+    }
+    flavorDimensions "api", "mode"
+
+    productFlavors {
+        minApi24 {
+            dimension "api"
+        }
+        demo {
+            dimension "mode"
+        }
+    }
+}
+
+fladle {
+    serviceAccountCredentials = project.layout.projectDirectory.file("flank-gradle-5cf02dc90531.json")
+    variant = "minApi24DemoDebug"
+}
+
+dependencies {
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation("androidx.navigation:navigation-fragment-ktx:2.3.0")
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.1'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test:rules:1.5.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+}

--- a/fladle-plugin/src/test/resources/android-project-multiple-flavor-dimensions/src/androidTest/java/com/osacky/flank/gradle/sample/ExampleInstrumentedTest.java
+++ b/fladle-plugin/src/test/resources/android-project-multiple-flavor-dimensions/src/androidTest/java/com/osacky/flank/gradle/sample/ExampleInstrumentedTest.java
@@ -1,0 +1,33 @@
+package com.osacky.flank.gradle.sample;
+
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.action.ViewActions.typeText;
+import java.lang.RuntimeException;
+
+@RunWith(AndroidJUnit4.class)
+public class ExampleInstrumentedTest {
+
+  @Rule
+  private final ActivityTestRule testRule = new ActivityTestRule(MainActivity.class);
+
+  @Test
+  public void seeView() {
+    onView(withId(R.id.text_view_hello)).check(matches(isDisplayed()));
+  }
+
+  @Test
+  public void runAndFail() {
+    throw new RuntimeException("Test failed");
+  }
+}

--- a/fladle-plugin/src/test/resources/android-project-multiple-flavor-dimensions/src/main/AndroidManifest.xml
+++ b/fladle-plugin/src/test/resources/android-project-multiple-flavor-dimensions/src/main/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest
+          xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application
+        android:label="@string/app_name"
+    >
+        <activity android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/fladle-plugin/src/test/resources/android-project-multiple-flavor-dimensions/src/main/java/com/osacky/flank/gradle/sample/MainActivity.java
+++ b/fladle-plugin/src/test/resources/android-project-multiple-flavor-dimensions/src/main/java/com/osacky/flank/gradle/sample/MainActivity.java
@@ -1,0 +1,13 @@
+package com.osacky.flank.gradle.sample;
+
+import androidx.appcompat.app.AppCompatActivity;
+import android.os.Bundle;
+
+public class MainActivity extends AppCompatActivity {
+
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
+  }
+}

--- a/fladle-plugin/src/test/resources/android-project-multiple-flavor-dimensions/src/main/res/layout/activity_main.xml
+++ b/fladle-plugin/src/test/resources/android-project-multiple-flavor-dimensions/src/main/res/layout/activity_main.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".MainActivity">
+
+    <TextView
+        android:id="@+id/text_view_hello"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Hello World!"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/fladle-plugin/src/test/resources/android-project-multiple-flavor-dimensions/src/main/res/values/strings.xml
+++ b/fladle-plugin/src/test/resources/android-project-multiple-flavor-dimensions/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Flank Gradle Plugin Sample</string>
+</resources>


### PR DESCRIPTION
## Summary

Fulladle manually constructs APK paths from `variant.productFlavors`, but the current logic does not handle variants with multiple flavor dimensions correctly.

In `FulladlePlugin.kt`, the flavor part is built like this:

https://github.com/runningcode/fladle/blob/0614f1f59ce78294c694920a97ae8848c17be12d/fladle-plugin/src/main/java/com/osacky/flank/gradle/FulladlePlugin.kt#L33-L34

```kotlin
val flavorName = variant.productFlavors.joinToString("") { it.second }
val flavorPath = variant.productFlavors.joinToString("/") { it.second }
```

For a variant composed from minApi24 and demo, this generates:

- flavor name: minApi24demo
- flavor path: minApi24/demo

However, AGP generates artifacts for minApi24DemoDebug like:

`build/outputs/apk/minApi24Demo/debug/app-minApi24-demo-debug.apk`
`build/outputs/apk/androidTest/minApi24Demo/debug/app-minApi24-demo-debug-androidTest.apk`

## Reproduction

Configure an Android module with multiple flavor dimensions:

```groovy
android {
    flavorDimensions "api", "mode"
    productFlavors {
        minApi24 {
            dimension "api"
        }
        demo {
            dimension "mode"
        }
    }
}
```

Then run Fulladle for minApi24DemoDebug.

## Expected behavior

Fulladle should reference the actual APK paths generated by AGP:

`build/outputs/apk/minApi24Demo/debug/app-minApi24-demo-debug.apk`
`build/outputs/apk/androidTest/minApi24Demo/debug/app-minApi24-demo-debug-androidTest.apk`

## Actual behavior

Fulladle generates paths using the slash-joined flavor path and concatenated flavor name:

`build/outputs/apk/minApi24/demo/debug/app-minApi24demo-debug.apk`
`build/outputs/apk/androidTest/minApi24/demo/debug/app-minApi24demo-debug-androidTest.apk`

These files do not exist, so the generated Flank config points to invalid APK paths.